### PR TITLE
Add structured logging and note tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Note: The `image` field is optional - if omitted, projects will use the default 
 
 ## 🔧 MCP Tools
 
-DockaShell exposes 5 MCP tools:
+DockaShell exposes several MCP tools:
 
 ### `list_projects`
 Lists all configured projects with their status.
@@ -246,8 +246,8 @@ Lists all configured projects with their status.
 Starts a Docker container for the specified project.
 
 ### `run_command`
-**Arguments:** `{"project_name": "string", "command": "string"}`
-Executes a shell command in the project container.
+**Arguments:** `{"project_name": "string", "command": "string", "log?": "string"}`
+Executes a shell command in the project container. When `log` is provided, the text is stored as an agent note before execution.
 
 ### `project_status`
 **Arguments:** `{"project_name": "string"}`
@@ -256,6 +256,14 @@ Returns detailed status information about the project container.
 ### `stop_project`
 **Arguments:** `{"project_name": "string"}`
 Stops the project container.
+
+### `write_log`
+**Arguments:** `{"project_name": "string", "type": "user|summary|agent", "text": "string"}`
+Writes an arbitrary note to the project log.
+
+### `read_log`
+**Arguments:** `{"project_name": "string", "type?": "string", "search?": "string", "skip?": "number", "limit?": "number", "concat?": "boolean"}`
+Returns log entries with simple filtering and pagination.
 
 ## 🛡️ Security Features
 
@@ -276,13 +284,15 @@ When `restricted_mode` is enabled:
 
 ## 📊 Logging
 
-Commands are logged to `~/.dockashell/logs/{project-name}.log`:
+Commands are logged to `~/.dockashell/logs/{project-name}.log` and a machine readable `*.jsonl` file:
 
 ```
 2024-05-22T10:30:15.123Z [START] project=web-app container=abc123 ports=3000:3000
 2024-05-22T10:30:16.456Z [EXEC] project=web-app command="npm install" exit_code=0 duration=2.3s
 2024-05-22T10:30:20.789Z [EXEC] project=web-app command="npm start" exit_code=0 duration=0.1s
 ```
+
+Use `write_log` to store notes and `read_log` to query previous entries.
 
 ## 🔌 MCP Client Integration
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -37,6 +37,7 @@ export class Logger {
       // Sanitize project name for filename
       const safeProjectName = projectName.replace(/[^a-zA-Z0-9_-]/g, '_');
       const logFile = path.join(this.logsDir, `${safeProjectName}.log`);
+      const jsonLogFile = path.join(this.logsDir, `${safeProjectName}.jsonl`);
       const timestamp = new Date().toISOString();
 
       let logEntry;
@@ -53,6 +54,15 @@ export class Logger {
       }
 
       await fs.appendFile(logFile, logEntry);
+
+      const jsonEntry = {
+        timestamp,
+        kind: 'command',
+        command,
+        result
+      };
+
+      await fs.appendFile(jsonLogFile, JSON.stringify(jsonEntry) + '\n');
     } catch (error) {
       console.error('Failed to log command:', error.message);
       // Don't throw - logging failures shouldn't break the main operation
@@ -69,6 +79,71 @@ export class Logger {
     } catch (error) {
       console.error('Failed to read logs:', error);
       return '';
+    }
+  }
+
+  async logNote(projectName, noteType, text) {
+    try {
+      if (!projectName || typeof projectName !== 'string') {
+        console.error('Invalid project name for logging:', projectName);
+        return;
+      }
+      if (!text || typeof text !== 'string') {
+        console.error('Invalid note text for logging:', text);
+        return;
+      }
+
+      await this.ensureLogsDirectory();
+
+      const safeProjectName = projectName.replace(/[^a-zA-Z0-9_-]/g, '_');
+      const logFile = path.join(this.logsDir, `${safeProjectName}.log`);
+      const jsonLogFile = path.join(this.logsDir, `${safeProjectName}.jsonl`);
+      const timestamp = new Date().toISOString();
+
+      const noteEntry = `${timestamp} [NOTE] project=${projectName} type=${noteType} ${text}\n`;
+      await fs.appendFile(logFile, noteEntry);
+
+      const jsonEntry = {
+        timestamp,
+        kind: 'note',
+        noteType,
+        text
+      };
+      await fs.appendFile(jsonLogFile, JSON.stringify(jsonEntry) + '\n');
+    } catch (error) {
+      console.error('Failed to log note:', error.message);
+    }
+  }
+
+  async readJsonLogs(projectName, { type, search, skip = 0, limit = 20 } = {}) {
+    try {
+      const safeProjectName = projectName.replace(/[^a-zA-Z0-9_-]/g, '_');
+      const jsonLogFile = path.join(this.logsDir, `${safeProjectName}.jsonl`);
+      if (!(await fs.pathExists(jsonLogFile))) {
+        return [];
+      }
+
+      const lines = (await fs.readFile(jsonLogFile, 'utf8'))
+        .split('\n')
+        .filter(Boolean);
+      let entries = lines.map(l => {
+        try { return JSON.parse(l); } catch { return null; }
+      }).filter(Boolean);
+
+      if (type) {
+        entries = entries.filter(e => e.kind === type || e.noteType === type);
+      }
+      if (search) {
+        entries = entries.filter(e => {
+          const target = e.command || e.text || '';
+          return target.includes(search);
+        });
+      }
+
+      return entries.slice(skip, skip + limit);
+    } catch (error) {
+      console.error('Failed to read JSON logs:', error.message);
+      return [];
     }
   }
 }

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -155,4 +155,20 @@ describe('Logger', () => {
     await expect(invalidLogger.logCommand('test', 'command', { type: 'exec' }))
       .resolves.not.toThrow();
   });
+
+  test('should log notes and read json logs', async () => {
+    const projectName = 'test-project';
+    await logger.logNote(projectName, 'user', 'remember this');
+    await logger.logCommand(projectName, 'echo hi', { type: 'exec', exitCode: 0 });
+
+    const jsonEntries = await logger.readJsonLogs(projectName);
+    expect(jsonEntries.length).toBe(2);
+    const kinds = jsonEntries.map(e => e.kind);
+    expect(kinds).toContain('note');
+    expect(kinds).toContain('command');
+
+    const filtered = await logger.readJsonLogs(projectName, { type: 'note' });
+    expect(filtered.length).toBe(1);
+    expect(filtered[0].noteType).toBe('user');
+  });
 });


### PR DESCRIPTION
## Summary
- implement JSONL logging alongside text log
- add `logNote` and querying helpers to logger
- expose `write_log` and `read_log` tools
- allow optional `log` field in `run_command`
- document new tools and logging format
- test new logging capabilities

## Testing
- `npm test`