### PR TITLE
Fix licensing and doc inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ dockashell/
 ├── package.json
 ├── README.md
 ├── tests/                  # Test suite
-└── create-examples.js       # Example project setup
+└── scripts/setup/create-examples.js       # Example project setup
 ```
 
 ## 🤝 Contributing
@@ -388,7 +388,7 @@ dockashell/
 
 ## 📄 License
 
-MIT License - see LICENSE file for details.
+Apache License 2.0 - see LICENSE file for details.
 
 ---
 

--- a/docs/DEFAULT-IMAGE-IMPLEMENTATION.md
+++ b/docs/DEFAULT-IMAGE-IMPLEMENTATION.md
@@ -15,7 +15,7 @@ This implementation adds a comprehensive default Docker image approach to DockaS
 
 ### Modified Files
 - `src/project-manager.js` - Updated to use default image (`dockashell/default-dev:latest`)
-- `create-examples.js` - Simplified example projects using default image
+- `scripts/setup/create-examples.js` - Simplified example projects using default image
 - `package.json` - Added new npm scripts
 - `README.md` - Updated documentation with default image information
 

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -20,7 +20,7 @@ dockashell/
 │   └── create-test-project.js   # Test project setup utility
 ├── package.json                  # Node.js dependencies
 ├── tests/                       # Test suite
-├── create-examples.js           # Project examples generator
+├── scripts/setup/create-examples.js           # Project examples generator
 └── README.md                    # Project documentation
 ```
 
@@ -48,6 +48,6 @@ dockashell/
 1. **Core changes**: Edit files in `src/`
 2. **Testing**: Run tests from `tests/` directory
 3. **Setup**: Use utilities from `utils/` for configuration
-4. **Examples**: Generate with `create-examples.js`
+4. **Examples**: Generate with `scripts/setup/create-examples.js`
 
 This structure maintains separation of concerns while keeping the project accessible and maintainable.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "dockashell",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "dockerode": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "debug": "npx @modelcontextprotocol/inspector node src/mcp-server.js",
     "test-tools": "node tests/test-mcp-tools.js",
     "setup-examples": "node scripts/setup/create-examples.js",
-    "configure-claude": "node configure-claude.js",
     "test": "node --experimental-vm-modules node_modules/.bin/jest",
     "build-image": "node scripts/image/build-default-image.js",
     "setup-image": "node scripts/setup/setup-default-image.js",
@@ -38,7 +37,7 @@
     "container"
   ],
   "author": "DockaShell",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "devDependencies": {
     "jest": "^29.7.0"
   }

--- a/scripts/setup/setup-complete.js
+++ b/scripts/setup/setup-complete.js
@@ -40,7 +40,7 @@ async function setupDockaShell() {
   try {
     // Import and run the examples script
     const { execSync } = await import('child_process');
-    execSync('node create-examples.js', { stdio: 'inherit' });
+    execSync('node scripts/setup/create-examples.js', { stdio: 'inherit' });
   } catch (error) {
     console.error('❌ Failed to create example projects:', error.message);
     process.exit(1);


### PR DESCRIPTION
## Summary
- remove unused `configure-claude` script
- update documentation to point to `scripts/setup/create-examples.js`
- align project license declarations with Apache 2.0

## Testing
- `npm test`