### PR TITLE
Enhance read_log tool output

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,30 @@ Stops the project container.
 Writes an arbitrary note to the project log.
 
 ### `read_log`
-**Arguments:** `{"project_name": "string", "type?": "string", "search?": "string", "skip?": "number", "limit?": "number", "concat?": "boolean"}`
-Returns log entries with simple filtering and pagination.
+**Arguments:** `{"project_name": "string", "type?": "string", "search?": "string", "skip?": "number", "limit?": "number", "fields?": "string[]"}`
+Returns formatted log entries with optional filtering and field selection.
+
+**Field Options:**
+- `timestamp`, `type`, `content` - Always included for context
+- `exit_code`, `duration` - Command execution metadata (commands only)
+- `output` - Command output preview, truncated to 200 chars for display (commands only)
+
+**Type Filtering:**
+- `"command"` - Shell command executions only
+- `"note"` - All note types (user, agent, summary)
+- `"user"`, `"agent"`, `"summary"` - Specific note types
+
+**Usage Examples:**
+```javascript
+// Recent activity overview
+read_log("project", {limit: 10})
+
+// Debug failed commands with output
+read_log("project", {type: "command", fields: ["timestamp", "type", "content", "exit_code", "output"]})
+
+// Search across commands and output
+read_log("project", {search: "error"})
+```
 
 ## 🛡️ Security Features
 

--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -252,12 +252,13 @@ export class ContainerManager {
 
       const duration = ((Date.now() - startTime) / 1000).toFixed(2);
 
-      // Log the command execution
+      // Log the command execution including full output for later preview
       await this.logger.logCommand(projectName, command, {
         type: 'exec',
         exitCode: result.exitCode,
         duration: `${duration}s`,
-        timedOut: result.timedOut
+        timedOut: result.timedOut,
+        output: result.stdout || ''
       });
 
       return {
@@ -277,7 +278,8 @@ export class ContainerManager {
           type: 'exec',
           exitCode: -1,
           duration: `${duration}s`,
-          timedOut: true
+          timedOut: true,
+          output: ''
         });
         
         return {

--- a/src/logger.js
+++ b/src/logger.js
@@ -59,7 +59,8 @@ export class Logger {
         timestamp,
         kind: 'command',
         command,
-        result
+        result,
+        output: result.output || ''
       };
 
       await fs.appendFile(jsonLogFile, JSON.stringify(jsonEntry) + '\n');
@@ -131,12 +132,21 @@ export class Logger {
       }).filter(Boolean);
 
       if (type) {
-        entries = entries.filter(e => e.kind === type || e.noteType === type);
+        if (type === 'note') {
+          entries = entries.filter(e => e.kind === 'note');
+        } else if (['user', 'agent', 'summary'].includes(type)) {
+          entries = entries.filter(e => e.kind === 'note' && e.noteType === type);
+        } else if (type === 'command') {
+          entries = entries.filter(e => e.kind === 'command');
+        } else {
+          entries = entries.filter(e => e.kind === type || e.noteType === type);
+        }
       }
       if (search) {
+        const lower = search.toLowerCase();
         entries = entries.filter(e => {
-          const target = e.command || e.text || '';
-          return target.includes(search);
+          const target = (e.command || '') + (e.text || '') + (e.output || '');
+          return target.toLowerCase().includes(lower);
         });
       }
 

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -203,20 +203,70 @@ class DockashellServer {
       'read_log',
       {
         project_name: z.string().describe('Project name'),
-        type: z.string().optional().describe('Filter by kind or note type'),
+        type: z.string().optional().describe("Filter by 'command', 'note', 'user', 'agent', 'summary'"),
         search: z.string().optional().describe('Search substring'),
         skip: z.number().int().optional().describe('Skip N entries'),
         limit: z.number().int().optional().describe('Limit number of entries'),
-        concat: z.boolean().optional().describe('Concatenate text output')
+        fields: z.array(z.string()).optional().describe(
+          'Fields to include: timestamp, type, content (always shown), exit_code, duration, output (preview)'
+        )
       },
-      async ({ project_name, type, search, skip = 0, limit = 20, concat = true }) => {
+      async ({ project_name, type, search, skip = 0, limit = 20, fields }) => {
         try {
           const entries = await this.logger.readJsonLogs(project_name, { type, search, skip, limit });
-          if (concat) {
-            const text = entries.map(e => e.command || e.text).join('\n');
-            return { content: [{ type: 'text', text }] };
-          }
-          return { content: [{ type: 'json', json: entries }] };
+
+          const validFields = ['timestamp', 'type', 'content', 'exit_code', 'duration', 'output'];
+          let selected = Array.isArray(fields) ? fields.filter(f => validFields.includes(f)) : ['timestamp', 'type', 'content'];
+          if (!selected.includes('timestamp')) selected.unshift('timestamp');
+          if (!selected.includes('type')) selected.splice(1, 0, 'type');
+
+          const text = entries.map(entry => {
+            const meta = [];
+            const typeLabel = entry.kind === 'command'
+              ? 'COMMAND'
+              : (entry.noteType || entry.kind || 'UNKNOWN').toUpperCase();
+
+            if (selected.includes('exit_code') && entry.kind === 'command' && entry.result?.exitCode !== undefined) {
+              meta.push(`exit_code=${entry.result.exitCode}`);
+            }
+            if (selected.includes('duration') && entry.kind === 'command' && entry.result?.duration) {
+              meta.push(`duration=${entry.result.duration}`);
+            }
+
+            let header = `## ${entry.timestamp} [${typeLabel}]`;
+            if (meta.length) header += ' ' + meta.join(' ');
+
+            const lines = [header];
+
+            if (selected.includes('content')) {
+              if (entry.kind === 'command') {
+                if (selected.includes('output')) {
+                  lines.push('```bash');
+                  lines.push(entry.command);
+                  lines.push('```');
+                } else {
+                  lines.push(entry.command);
+                }
+              } else {
+                lines.push(entry.text);
+              }
+            }
+
+            if (selected.includes('output') && entry.kind === 'command' && entry.output) {
+              lines.push('');
+              lines.push('**Output:**');
+              lines.push('```');
+              const displayOutput = entry.output.length > 200
+                ? entry.output.substring(0, 200) + '...'
+                : entry.output;
+              lines.push(displayOutput);
+              lines.push('```');
+            }
+
+            return lines.join('\n');
+          }).join('\n\n');
+
+          return { content: [{ type: 'text', text: text || 'No log entries found' }] };
         } catch (error) {
           throw new Error(`Failed to read log: ${error.message}`);
         }

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -159,7 +159,7 @@ describe('Logger', () => {
   test('should log notes and read json logs', async () => {
     const projectName = 'test-project';
     await logger.logNote(projectName, 'user', 'remember this');
-    await logger.logCommand(projectName, 'echo hi', { type: 'exec', exitCode: 0 });
+    await logger.logCommand(projectName, 'echo hi', { type: 'exec', exitCode: 0, output: 'hello world' });
 
     const jsonEntries = await logger.readJsonLogs(projectName);
     expect(jsonEntries.length).toBe(2);
@@ -170,5 +170,16 @@ describe('Logger', () => {
     const filtered = await logger.readJsonLogs(projectName, { type: 'note' });
     expect(filtered.length).toBe(1);
     expect(filtered[0].noteType).toBe('user');
+  });
+
+  test('should include command output preview and search it', async () => {
+    const projectName = 'output-project';
+    await logger.logCommand(projectName, 'echo preview', { type: 'exec', exitCode: 0, output: 'preview text' });
+
+    const entries = await logger.readJsonLogs(projectName);
+    expect(entries[0].output).toBe('preview text');
+
+    const searched = await logger.readJsonLogs(projectName, { search: 'preview' });
+    expect(searched.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- store full command output but truncate when displaying logs
- document field options and usage of `read_log`
- update schema description for `read_log` fields

## Testing
- `npm test`
