### PR TITLE
Finalize trace logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ DockaShell enables AI agents to work safely and effectively in isolated environm
 
 ## 🖥️ Terminal User Interface (TUI)
 
-DockaShell includes a Terminal User Interface for viewing agent activity and project logs.
+DockaShell includes a Terminal User Interface for viewing agent activity and project traces.
 
 ### Usage
 

--- a/docs/logging/06-IMPLEMENTATION_GUIDE.md
+++ b/docs/logging/06-IMPLEMENTATION_GUIDE.md
@@ -11,8 +11,8 @@ structure.
    for a single project. Each recorder manages its own session identifier and
    exposes helper methods like `execution()` and `observation()`.
 3. **Update `Logger`** – retain its public methods but internally call the new
-   components. During Phase&nbsp;1 the original per project log files are kept and
-   the new trace files receive the same information.
+   components. Legacy per‑project log files were removed in Phase&nbsp;3 so only
+   structured trace files are written.
 4. **Use the facade** – other modules continue to instantiate `Logger` as
    before. No external API changes are required.
 

--- a/docs/logging/07-PROGRESS_TRACKING.md
+++ b/docs/logging/07-PROGRESS_TRACKING.md
@@ -11,4 +11,8 @@ the new logging system.
   implemented along with the updated `Logger` facade.
 - **Status 2025-05-02:** Added recorder cleanup on shutdown and moved trace sessions to `sessions/` directory on close.
 
+- **Status 2025-05-03:** Legacy project log files removed. MCP tools renamed to
+  `write_trace` and `read_traces`. Documentation updated for the new trace-only
+  system.
+
 Add further notes below as the migration continues.

--- a/docs/logging/08-CLEANUP_GUIDE.md
+++ b/docs/logging/08-CLEANUP_GUIDE.md
@@ -1,0 +1,10 @@
+# Phase 3 Cleanup Guide
+
+The final migration step removes the legacy per-project log files. Only `system.log` and structured trace files remain.
+
+## Removing old logs
+
+1. Delete the directory `~/.dockashell/logs/` if it still contains `*.log` or `*.jsonl` files.
+2. Each project continues to store traces under `~/.dockashell/projects/{name}/traces/`.
+
+After cleanup DockaShell will write agent activity exclusively to the trace files.

--- a/scripts/debug/test.js
+++ b/scripts/debug/test.js
@@ -89,9 +89,9 @@ async function runTests() {
     duration: '0.1s'
   });
   console.log('   ✓ Command logged successfully');
-  
-  const logs = await logger.getProjectLogs('test-project');
-  console.log(`   Log entry created: ${logs.split('\n').length - 1} lines`);
+
+  const traces = await logger.readTraces('test-project');
+  console.log(`   Trace entries: ${traces.length}`);
   console.log('   ✓ Logger working\n');
 
   console.log('✅ All core components working correctly!');

--- a/src/logger.js
+++ b/src/logger.js
@@ -6,16 +6,7 @@ import { TraceRecorder } from './trace-recorder.js';
 
 export class Logger {
   constructor() {
-    this.logsDir = path.join(os.homedir(), '.dockashell', 'logs');
     this.traceRecorders = new Map();
-  }
-
-  get logDir() {
-    return this.logsDir;
-  }
-
-  set logDir(dir) {
-    this.logsDir = dir;
   }
 
   getTraceRecorder(projectName) {
@@ -25,9 +16,6 @@ export class Logger {
     return this.traceRecorders.get(projectName);
   }
 
-  async ensureLogsDirectory() {
-    await fs.ensureDir(this.logsDir);
-  }
 
   async logCommand(projectName, command, result) {
     try {
@@ -42,9 +30,7 @@ export class Logger {
         return;
       }
 
-      await this.ensureLogsDirectory();
-
-      // New tracing behaviour
+      // Record trace
       systemLogger.debug('Command executed', {
         projectName,
         command: (command || '').substring(0, 50)
@@ -52,55 +38,12 @@ export class Logger {
       const recorder = this.getTraceRecorder(projectName);
       await recorder.execution('run_command', { command }, result);
 
-      // Sanitize project name for filename
-      const safeProjectName = projectName.replace(/[^a-zA-Z0-9_-]/g, '_');
-      const logFile = path.join(this.logsDir, `${safeProjectName}.log`);
-      const jsonLogFile = path.join(this.logsDir, `${safeProjectName}.jsonl`);
-      const timestamp = new Date().toISOString();
-
-      let logEntry;
-      if (result.type === 'start') {
-        logEntry = `${timestamp} [START] project=${projectName} container=${result.containerId || 'unknown'} ports=${result.ports || 'none'}\n`;
-      } else if (result.type === 'stop') {
-        logEntry = `${timestamp} [STOP] project=${projectName} container=${result.containerId || 'unknown'}\n`;
-      } else if (result.type === 'exec') {
-        const duration = result.duration || '0s';
-        const safeCommand = (command || '').replace(/[\r\n]/g, ' ').substring(0, 200);
-        logEntry = `${timestamp} [EXEC] project=${projectName} command="${safeCommand}" exit_code=${result.exitCode !== undefined ? result.exitCode : 'unknown'} duration=${duration}\n`;
-      } else {
-        logEntry = `${timestamp} [INFO] project=${projectName} action="${result.action || 'unknown'}"\n`;
-      }
-
-      await fs.appendFile(logFile, logEntry);
-
-      // Fix: Don't duplicate output - the result object already contains it
-      const jsonEntry = {
-        timestamp,
-        kind: 'command',
-        command,
-        result
-        // Removed: output: result.output || '' - this was causing duplication
-      };
-
-      await fs.appendFile(jsonLogFile, JSON.stringify(jsonEntry) + '\n');
     } catch (error) {
       console.error('Failed to log command:', error.message);
       // Don't throw - logging failures shouldn't break the main operation
     }
   }
 
-  async getProjectLogs(projectName) {
-    try {
-      const logFile = path.join(this.logsDir, `${projectName}.log`);
-      if (await fs.pathExists(logFile)) {
-        return await fs.readFile(logFile, 'utf-8');
-      }
-      return '';
-    } catch (error) {
-      console.error('Failed to read logs:', error);
-      return '';
-    }
-  }
 
   async logNote(projectName, noteType, text) {
     try {
@@ -113,48 +56,56 @@ export class Logger {
         return;
       }
 
-      await this.ensureLogsDirectory();
-
       systemLogger.info('Note recorded', {
         projectName,
         noteType
       });
       const recorder = this.getTraceRecorder(projectName);
       await recorder.observation(noteType, text);
-
-      const safeProjectName = projectName.replace(/[^a-zA-Z0-9_-]/g, '_');
-      const logFile = path.join(this.logsDir, `${safeProjectName}.log`);
-      const jsonLogFile = path.join(this.logsDir, `${safeProjectName}.jsonl`);
-      const timestamp = new Date().toISOString();
-
-      const noteEntry = `${timestamp} [NOTE] project=${projectName} type=${noteType} ${text}\n`;
-      await fs.appendFile(logFile, noteEntry);
-
-      const jsonEntry = {
-        timestamp,
-        kind: 'note',
-        noteType,
-        text
-      };
-      await fs.appendFile(jsonLogFile, JSON.stringify(jsonEntry) + '\n');
     } catch (error) {
       console.error('Failed to log note:', error.message);
     }
   }
 
-  async readJsonLogs(projectName, { type, search, skip = 0, limit = 20 } = {}) {
+  async readTraces(projectName, { type, search, skip = 0, limit = 20 } = {}) {
     try {
-      const safeProjectName = projectName.replace(/[^a-zA-Z0-9_-]/g, '_');
-      const jsonLogFile = path.join(this.logsDir, `${safeProjectName}.jsonl`);
-      if (!(await fs.pathExists(jsonLogFile))) {
+      const tracesFile = path.join(
+        os.homedir(),
+        '.dockashell',
+        'projects',
+        projectName,
+        'traces',
+        'current.jsonl'
+      );
+      if (!(await fs.pathExists(tracesFile))) {
         return [];
       }
 
-      const lines = (await fs.readFile(jsonLogFile, 'utf8'))
+      const lines = (await fs.readFile(tracesFile, 'utf8'))
         .split('\n')
         .filter(Boolean);
       let entries = lines.map(l => {
-        try { return JSON.parse(l); } catch { return null; }
+        try {
+          const trace = JSON.parse(l);
+          if (trace.tool === 'run_command') {
+            return {
+              timestamp: trace.timestamp,
+              kind: 'command',
+              command: trace.command,
+              result: trace.result
+            };
+          } else if (trace.tool === 'write_trace') {
+            return {
+              timestamp: trace.timestamp,
+              kind: 'note',
+              noteType: trace.type,
+              text: trace.text
+            };
+          }
+          return { timestamp: trace.timestamp, ...trace };
+        } catch {
+          return null;
+        }
       }).filter(Boolean);
 
       if (type) {
@@ -178,7 +129,7 @@ export class Logger {
 
       return entries.slice(skip, skip + limit);
     } catch (error) {
-      console.error('Failed to read JSON logs:', error.message);
+      console.error('Failed to read traces:', error.message);
       return [];
     }
   }

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -209,7 +209,7 @@ class DockashellServer {
       },
       async ({ project_name, type, search, skip = 0, limit = 20, fields }) => {
         try {
-          const entries = await this.logger.readJsonLogs(project_name, { type, search, skip, limit });
+          const entries = await this.logger.readTraces(project_name, { type, search, skip, limit });
 
           const validFields = ['timestamp', 'type', 'content', 'exit_code', 'duration', 'output'];
           let selected = Array.isArray(fields) ? fields.filter(f => validFields.includes(f)) : ['timestamp', 'type', 'content'];


### PR DESCRIPTION
## Summary
- drop legacy project log file writes from `Logger`
- migrate MCP server to new `readTraces` method
- adapt logger tests to check trace files
- update docs to reflect trace-only logging
- add cleanup guide for removing old logs

## Testing
- `npm test`