### PR TITLE
Add git_apply MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@ Starts a Docker container for the specified project.
 **Arguments:** `{"project_name": "string", "command": "string"}`
 Executes a shell command in the project container.
 
+### `git_apply`
+**Arguments:** `{"project_name": "string", "diff": "string"}`
+Applies a unified git diff inside the project container. The patch is only applied if `git apply --check` succeeds, otherwise an error is returned.
+
 ### `project_status`
 **Arguments:** `{"project_name": "string"}`
 Returns detailed status information about the project container.

--- a/docs/git_apply_tool.md
+++ b/docs/git_apply_tool.md
@@ -1,0 +1,23 @@
+# git_apply MCP Tool
+
+The `git_apply` tool lets an LLM apply a unified diff inside a project container.
+It first runs `git apply --check` to ensure the patch will apply cleanly. If the
+check succeeds, the patch is applied with `git apply`. If not, the tool returns
+an error and no files are changed.
+
+## Arguments
+
+```json
+{ "project_name": "string", "diff": "string" }
+```
+
+- `project_name` – target project container
+- `diff` – unified git diff to apply
+
+## LLM Usage Guidance
+
+1. Send small, focused diffs to avoid conflicts.
+2. Inspect the tool response; on errors, adjust the diff and retry.
+3. After a successful apply, use `run_command` for additional git operations
+   like commits.
+4. Avoid very large diffs as they may exceed resource limits.

--- a/test/integration/test-mcp-tools.js
+++ b/test/integration/test-mcp-tools.js
@@ -116,10 +116,24 @@ async function testMCPTools() {
   } catch (error) {
     console.log('✅ run_command properly rejected empty command:', error.message);
   }
-  
-  // Test 5: Stop project (should handle gracefully)
+
+  // Test 5: git_apply with nonexistent project
   try {
-    console.log('5. Testing stop_project...');
+    console.log('5. Testing git_apply with nonexistent project...');
+    const diff = 'diff --git a/foo.txt b/foo.txt\nindex 0000000..e69de29 100644\n--- a/foo.txt\n+++ b/foo.txt\n@@\n+test\n';
+    const response = await runMCPCommand('git_apply', { project_name: 'missing', diff });
+    if (response.error || response.result?.isError) {
+      console.log('✅ git_apply handled error:', response.result?.content?.[0]?.text || response.error?.message);
+    } else {
+      console.log('❌ git_apply should have failed for nonexistent project');
+    }
+  } catch (error) {
+    console.log('✅ git_apply handled error gracefully:', error.message);
+  }
+
+  // Test 6: Stop project (should handle gracefully)
+  try {
+    console.log('6. Testing stop_project...');
     const response = await runMCPCommand('stop_project', { project_name: 'test-project' });
     if (response.error || response.result?.isError) {
       const errorMsg = response.result?.content?.[0]?.text || response.error?.message;


### PR DESCRIPTION
## Summary
- add `git_apply` tool for applying patches in project containers
- document new tool and usage instructions
- implement applyPatch in container manager
- test git_apply handling via integration tests

## Testing
- `npm test`
- `npm run test:integration` *(fails: Status check failed due to missing Docker)*
- `node test/integration/test-mcp-tools.js`
- `node test/integration/test-server.js`
- `node test/integration/test-timeout.js`
