### PR TITLE
Improve git_apply logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Agent traces are stored in `~/.dockashell/projects/{project-name}/traces/current
 {"id":"tr_abc123","tool":"start_project","trace_type":"execution","project_name":"web-app","result":{"success":true}}
 {"id":"tr_def456","tool":"write_trace","trace_type":"observation","type":"agent","text":"Planning React app"}
 {"id":"tr_ghi789","tool":"run_command","trace_type":"execution","command":"npm start","result":{"exitCode":0,"duration":"0.1s"}}
+{"id":"tr_xyz000","tool":"git_apply","trace_type":"execution","diff":"diff --git a/foo b/foo","result":{"exitCode":0,"duration":"0.2s"}}
 ```
 
 Use `write_trace` to store notes and `read_traces` to query previous entries.

--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -367,13 +367,17 @@ export class ContainerManager {
 
       const duration = ((Date.now() - startTime) / 1000).toFixed(2);
 
-      await this.logger.logCommand(projectName, 'git_apply', {
-        type: 'git_apply',
-        exitCode: result.exitCode,
-        duration: `${duration}s`,
-        timedOut: result.timedOut,
-        output: result.stdout || ''
-      });
+      await this.logger.logToolExecution(
+        projectName,
+        'git_apply',
+        { diff },
+        {
+          exitCode: result.exitCode,
+          duration: `${duration}s`,
+          timedOut: result.timedOut,
+          output: result.stdout || ''
+        }
+      );
 
       return {
         success: result.exitCode === 0,
@@ -386,13 +390,17 @@ export class ContainerManager {
 
     } catch (error) {
       const duration = ((Date.now() - startTime) / 1000).toFixed(2);
-      await this.logger.logCommand(projectName, 'git_apply', {
-        type: 'git_apply',
-        exitCode: -1,
-        duration: `${duration}s`,
-        timedOut: false,
-        output: ''
-      });
+      await this.logger.logToolExecution(
+        projectName,
+        'git_apply',
+        { diff },
+        {
+          exitCode: -1,
+          duration: `${duration}s`,
+          timedOut: false,
+          output: ''
+        }
+      );
       throw error;
     }
   }

--- a/src/logger.js
+++ b/src/logger.js
@@ -44,6 +44,20 @@ export class Logger {
     }
   }
 
+  async logToolExecution(projectName, toolName, params, result) {
+    try {
+      if (!projectName || typeof projectName !== 'string') {
+        console.error('Invalid project name for logging:', projectName);
+        return;
+      }
+
+      const recorder = this.getTraceRecorder(projectName);
+      await recorder.execution(toolName, params, result || {});
+    } catch (error) {
+      console.error('Failed to log tool execution:', error.message);
+    }
+  }
+
 
   async logNote(projectName, noteType, text) {
     try {
@@ -94,6 +108,13 @@ export class Logger {
               command: trace.command,
               result: trace.result
             };
+          } else if (trace.tool === 'git_apply') {
+            return {
+              timestamp: trace.timestamp,
+              kind: 'git_apply',
+              diff: trace.diff,
+              result: trace.result
+            };
           } else if (trace.tool === 'write_trace') {
             return {
               timestamp: trace.timestamp,
@@ -115,6 +136,8 @@ export class Logger {
           entries = entries.filter(e => e.kind === 'note' && e.noteType === type);
         } else if (type === 'command') {
           entries = entries.filter(e => e.kind === 'command');
+        } else if (type === 'git_apply') {
+          entries = entries.filter(e => e.kind === 'git_apply');
         } else {
           entries = entries.filter(e => e.kind === type || e.noteType === type);
         }

--- a/src/tui/entry-utils.js
+++ b/src/tui/entry-utils.js
@@ -168,6 +168,40 @@ export const buildEntryLines = (entry, maxLines = Infinity, terminalWidth = 80, 
         outputLines.forEach((line) => lines.push({ type: 'output', text: line }));
       }
     }
+  } else if (entry.kind === 'git_apply') {
+    const result = entry.result || {};
+    const exitCode = result.exitCode !== undefined ? result.exitCode : 'N/A';
+    const duration = result.duration || 'N/A';
+
+    lines.push({
+      type: 'header',
+      icon: '🩹',
+      timestamp: formatTimestamp(entry.timestamp),
+      typeText: `GIT_APPLY | Exit: ${exitCode} | ${duration}`,
+      typeColor: 'green'
+    });
+
+    const diff = entry.diff || '';
+
+    if (compact) {
+      const first = diff.split('\n')[0];
+      lines.push({ type: 'command', text: truncateText(first, contentAvailableWidth) });
+    } else {
+      const diffLines = formatMultilineText(diff, contentAvailableWidth - 2, Infinity, true);
+      diffLines.forEach((line, index) => {
+        lines.push({ type: 'command', text: index === 0 ? line : `  ${line}` });
+      });
+
+      if (showOutput && result.output && result.output.trim()) {
+        lines.push({
+          type: 'separator',
+          text: '─'.repeat(Math.min(contentAvailableWidth, 60))
+        });
+
+        const outputLines = formatCommandOutput(result.output.trim(), contentAvailableWidth, maxLines - lines.length);
+        outputLines.forEach((line) => lines.push({ type: 'output', text: line }));
+      }
+    }
   } else {
     // Unknown entry type
     const type = entry.type || entry.kind || 'UNKNOWN';

--- a/src/tui/read-traces.js
+++ b/src/tui/read-traces.js
@@ -66,6 +66,13 @@ export async function readTraceEntries(projectName, maxEntries = 100, session = 
           command: trace.command,
           result: trace.result
         };
+      } else if (trace.tool === 'git_apply') {
+        entry = {
+          timestamp: trace.timestamp,
+          kind: 'git_apply',
+          diff: trace.diff,
+          result: trace.result
+        };
       } else if (trace.tool === 'write_trace') {
         entry = {
           timestamp: trace.timestamp,


### PR DESCRIPTION
## Summary
- log `git_apply` as its own tool and include patch text
- support `git_apply` traces in Logger and TUI
- display `git_apply` with custom icon and color
- document git_apply traces in README

## Testing
- `npm test`
- `npm run test:integration`