### PR TITLE
Enhance git_apply logging and TUI display

### DIFF
--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -375,7 +375,7 @@ export class ContainerManager {
           exitCode: result.exitCode,
           duration: `${duration}s`,
           timedOut: result.timedOut,
-          output: result.stdout || ''
+          output: [result.stdout, result.stderr].filter(Boolean).join('\n')
         }
       );
 
@@ -398,7 +398,7 @@ export class ContainerManager {
           exitCode: -1,
           duration: `${duration}s`,
           timedOut: false,
-          output: ''
+          output: error.message || ''
         }
       );
       throw error;

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -261,12 +261,14 @@ class DockashellServer {
             const meta = [];
             const typeLabel = entry.kind === 'command'
               ? 'COMMAND'
-              : (entry.noteType || entry.kind || 'UNKNOWN').toUpperCase();
+              : entry.kind === 'git_apply'
+                ? 'GIT_APPLY'
+                : (entry.noteType || entry.kind || 'UNKNOWN').toUpperCase();
 
-            if (selected.includes('exit_code') && entry.kind === 'command' && entry.result?.exitCode !== undefined) {
+            if (selected.includes('exit_code') && (entry.kind === 'command' || entry.kind === 'git_apply') && entry.result?.exitCode !== undefined) {
               meta.push(`exit_code=${entry.result.exitCode}`);
             }
-            if (selected.includes('duration') && entry.kind === 'command' && entry.result?.duration) {
+            if (selected.includes('duration') && (entry.kind === 'command' || entry.kind === 'git_apply') && entry.result?.duration) {
               meta.push(`duration=${entry.result.duration}`);
             }
 
@@ -284,12 +286,14 @@ class DockashellServer {
                 } else {
                   lines.push(entry.command);
                 }
+              } else if (entry.kind === 'git_apply') {
+                lines.push(entry.diff);
               } else {
                 lines.push(entry.text);
               }
             }
 
-            if (selected.includes('output') && entry.kind === 'command' && entry.result?.output) {
+            if (selected.includes('output') && (entry.kind === 'command' || entry.kind === 'git_apply') && entry.result?.output) {
               lines.push('');
               lines.push('**Output:**');
               lines.push('```');

--- a/src/tui/LogViewer.js
+++ b/src/tui/LogViewer.js
@@ -22,7 +22,7 @@ const renderLines = (lines, selected, isModal = false) =>
     if (line.type === 'command') {
       return React.createElement(
         Text,
-        { key: idx, bold: selected && !isModal, color: isModal ? 'white' : 'cyan', wrap: 'truncate-end' },
+        { key: idx, bold: selected && !isModal, color: isModal ? 'white' : 'gray', wrap: 'truncate-end' },
         line.text
       );
     }

--- a/src/tui/entry-utils.js
+++ b/src/tui/entry-utils.js
@@ -93,14 +93,15 @@ export const buildEntryLines = (entry, maxLines = Infinity, terminalWidth = 80, 
     const result = entry.result || {};
     const exitCode = result.exitCode !== undefined ? result.exitCode : 'N/A';
     const duration = result.duration || 'N/A';
-    
+    const typeColor = exitCode === 0 ? 'green' : 'red';
+
     // First line: header with timestamp, command type, exit code, and duration
     lines.push({
       type: 'header',
       icon: '💻',
       timestamp: formatTimestamp(entry.timestamp),
       typeText: `COMMAND | Exit: ${exitCode} | ${duration}`,
-      typeColor: 'cyan'
+      typeColor
     });
 
     // Command lines
@@ -114,14 +115,7 @@ export const buildEntryLines = (entry, maxLines = Infinity, terminalWidth = 80, 
       if (command.includes('\n')) {
         const firstLine = command.split('\n')[0];
         const lineCount = command.split('\n').length;
-        
-        if (firstLine.includes('<<')) {
-          // Heredoc command
-          displayCommand = firstLine + ` ... (${lineCount} lines)`;
-        } else {
-          // Other multi-line command
-          displayCommand = firstLine + ` ... (+${lineCount - 1} lines)`;
-        }
+        displayCommand = firstLine + ` ... (${lineCount} lines)`;
       }
       
       // Truncate to available width
@@ -173,19 +167,22 @@ export const buildEntryLines = (entry, maxLines = Infinity, terminalWidth = 80, 
     const exitCode = result.exitCode !== undefined ? result.exitCode : 'N/A';
     const duration = result.duration || 'N/A';
 
+    const typeColor = exitCode === 0 ? 'green' : 'red';
     lines.push({
       type: 'header',
       icon: '🩹',
       timestamp: formatTimestamp(entry.timestamp),
       typeText: `GIT_APPLY | Exit: ${exitCode} | ${duration}`,
-      typeColor: 'green'
+      typeColor
     });
 
     const diff = entry.diff || '';
 
     if (compact) {
-      const first = diff.split('\n')[0];
-      lines.push({ type: 'command', text: truncateText(first, contentAvailableWidth) });
+      const diffLines = diff.split('\n');
+      const first = diffLines[0];
+      const display = diffLines.length > 1 ? `${first} ... (${diffLines.length} lines)` : first;
+      lines.push({ type: 'command', text: truncateText(display, contentAvailableWidth) });
     } else {
       const diffLines = formatMultilineText(diff, contentAvailableWidth - 2, Infinity, true);
       diffLines.forEach((line, index) => {

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -75,4 +75,18 @@ describe('Logger', () => {
     assert.ok(texts.includes('First entry'));
     assert.ok(texts.includes('Second entry'));
   });
+
+  test('should log git_apply traces', async () => {
+    const diff = 'diff --git a/a b/a\n--- a/a\n+++ b/a\n@@\n-test\n+test2';
+    await logger.logToolExecution('test-project', 'git_apply', { diff }, {
+      exitCode: 1,
+      duration: '0.2s',
+      output: 'error message'
+    });
+
+    const entries = await logger.readTraces('test-project', { type: 'git_apply', limit: 5 });
+    assert.strictEqual(entries.length, 1);
+    assert.ok(entries[0].diff.startsWith('diff --git'));
+    assert.strictEqual(entries[0].result.exitCode, 1);
+  });
 });

--- a/test/read-traces.test.js
+++ b/test/read-traces.test.js
@@ -42,4 +42,23 @@ describe('read-traces helpers', () => {
     const currentEntries = await readTraceEntries('proj', 10, 'current');
     assert.strictEqual(currentEntries.length, 1);
   });
+
+  test('parses git_apply entries', async () => {
+    const current = getTraceFile('proj', 'current');
+    await fs.ensureDir(path.dirname(current));
+    const entry = {
+      timestamp: new Date().toISOString(),
+      tool: 'git_apply',
+      trace_type: 'execution',
+      diff: 'diff --git a/a b/a',
+      result: { exitCode: 0, duration: '0.1s' }
+    };
+    await fs.writeFile(current, JSON.stringify(entry) + '\n');
+
+    const entries = await readTraceEntries('proj', 10, 'current');
+    assert.strictEqual(entries.length, 1);
+    assert.strictEqual(entries[0].kind, 'git_apply');
+    assert.strictEqual(entries[0].diff, 'diff --git a/a b/a');
+    assert.strictEqual(entries[0].result.exitCode, 0);
+  });
 });


### PR DESCRIPTION
## Summary
- improve `git_apply` logging to capture stderr and error message on failure
- include `git_apply` traces when reading traces
- color command headers green on success and red on failure
- unify multi-line text summary format and diff previews
- show command lines in light gray for consistent second-line style
- add tests for git_apply trace handling

## Testing
- `npm test`