### PR TITLE
Implement trace session rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,10 @@ Agent traces are stored in `~/.dockashell/projects/{project-name}/traces/current
 
 Use `write_trace` to store notes and `read_traces` to query previous entries.
 
+Trace sessions rotate automatically when there are more than four hours between
+entries. The timeout can be changed in `~/.dockashell/config.json` using
+`logging.traces.session_timeout` (e.g. `"2h"`).
+
 ## 🔌 MCP Client Integration
 
 Add to your MCP client configuration:

--- a/docs/logging/07-PROGRESS_TRACKING.md
+++ b/docs/logging/07-PROGRESS_TRACKING.md
@@ -20,4 +20,8 @@ the new logging system.
 - **Status 2025-05-05:** Session navigation added. Viewer can jump between
   archived sessions stored under `traces/sessions/`.
 
+- **Status 2025-05-06:** Session timeout configurable via
+  `logging.traces.session_timeout`. Recorder rotates files after periods of
+  inactivity.
+
 Add further notes below as the migration continues.

--- a/src/config.js
+++ b/src/config.js
@@ -16,6 +16,11 @@ const defaultConfig = {
       recent: [],
     },
   },
+  logging: {
+    traces: {
+      session_timeout: '4h',
+    },
+  },
 };
 
 export async function loadConfig() {
@@ -34,6 +39,13 @@ export async function loadConfig() {
     if (!cfg.tui.display.max_visible_entries) {
       cfg.tui.display.max_visible_entries =
         defaultConfig.tui.display.max_visible_entries;
+    }
+    if (!cfg.logging) cfg.logging = { ...defaultConfig.logging };
+    if (!cfg.logging.traces)
+      cfg.logging.traces = { ...defaultConfig.logging.traces };
+    if (!cfg.logging.traces.session_timeout) {
+      cfg.logging.traces.session_timeout =
+        defaultConfig.logging.traces.session_timeout;
     }
     return cfg;
   } catch {

--- a/test/trace-recorder.test.js
+++ b/test/trace-recorder.test.js
@@ -40,10 +40,18 @@ describe('TraceRecorder', () => {
     const fileExists = await fs.pathExists(recorder.currentFile);
     assert.ok(fileExists);
     await recorder.close();
-    const sessionFile = path.join(
-      recorder.sessionsDir,
-      `${recorder.sessionId}.jsonl`
-    );
-    assert.ok(await fs.pathExists(sessionFile));
+    const files = await fs.readdir(recorder.sessionsDir);
+    assert.strictEqual(files.length, 1);
+  });
+
+  test('rotates session after timeout', async () => {
+    await recorder.observation('user', 'first');
+    // simulate 5h later
+    recorder.lastTraceTime -= 5 * 60 * 60 * 1000;
+    await recorder.observation('user', 'second');
+    const files = await fs.readdir(recorder.sessionsDir);
+    assert.strictEqual(files.length, 1);
+    const currentExists = await fs.pathExists(recorder.currentFile);
+    assert.ok(currentExists);
   });
 });


### PR DESCRIPTION
## Summary
- allow configuration for trace session timeout
- rotate trace sessions in `TraceRecorder` when gap exceeds timeout
- honor timeout via `Logger`
- document behaviour and update progress tracking
- test session rotation

## Testing
- `npm test`