### PR TITLE
Switch git_apply to aider-based apply_diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,9 @@ Starts a Docker container for the specified project.
 **Arguments:** `{"project_name": "string", "command": "string"}`
 Executes a shell command in the project container.
 
-### `git_apply`
+### `apply_diff`
 **Arguments:** `{"project_name": "string", "diff": "string"}`
-Applies a unified git diff inside the project container with automatic whitespace fixing. Optimized for incremental file edits with precise error reporting.
+Applies an [Aider diff](docs/better-edit-tool/aider.md) inside the project container using `aider --apply`. More tolerant than `git apply` for iterative edits.
 
 ### `project_status`
 **Arguments:** `{"project_name": "string"}`
@@ -316,7 +316,7 @@ Agent traces are stored in `~/.dockashell/projects/{project-name}/traces/current
 {"id":"tr_abc123","tool":"start_project","trace_type":"execution","project_name":"web-app","result":{"success":true}}
 {"id":"tr_def456","tool":"write_trace","trace_type":"observation","type":"agent","text":"Planning React app"}
 {"id":"tr_ghi789","tool":"run_command","trace_type":"execution","command":"npm start","result":{"exitCode":0,"duration":"0.1s"}}
-{"id":"tr_xyz000","tool":"git_apply","trace_type":"execution","diff":"diff --git a/foo b/foo","result":{"exitCode":0,"duration":"0.2s"}}
+{"id":"tr_xyz000","tool":"apply_diff","trace_type":"execution","diff":"diff --git a/foo b/foo","result":{"exitCode":0,"duration":"0.2s"}}
 ```
 
 Use `write_trace` to store notes and `read_traces` to query previous entries.

--- a/docs/apply-diff-tool.md
+++ b/docs/apply-diff-tool.md
@@ -1,11 +1,11 @@
-# git_apply MCP Tool (Incremental File Edits)
+# apply_diff MCP Tool (Incremental File Edits)
 
-The `git_apply` tool enables precise, incremental file modifications by applying unified diffs directly inside project containers. Optimized for small, focused changes that build up complex edits through multiple iterations.
+The `apply_diff` tool enables flexible, incremental file updates by feeding [Aider](better-edit-tool/aider.md) diff blocks to `aider --apply` inside the project container. Optimized for small, focused changes that build up complex edits through multiple iterations.
 
 ## How It Works
 
-- Executes `git apply --whitespace=fix -` with automatic newline handling
-- Applies patches immediately with intelligent whitespace normalization
+- Executes `aider --apply -` with automatic newline handling
+- Applies patches using Aider's tolerant diff matching
 - Returns detailed exit codes and error messages for debugging
 - Handles stream transmission reliably within Docker containers
 
@@ -16,14 +16,14 @@ The `git_apply` tool enables precise, incremental file modifications by applying
 ```
 
 - `project_name` – Target project container name
-- `diff` – Unified git diff in standard format (automatic newline handling)
+- `diff` – Aider diff format string (automatic newline handling)
 
 ## LLM Usage Guidance
 
 ### Best Practices
 
 1. **Send small, focused diffs** – Single logical changes work best
-2. **Ensure accurate context** – @@ line numbers and context lines must match target file exactly
+2. **Include a bit of context** – At least one unchanged line around the edit helps Aider match correctly
 3. **Use incremental approach** – Build complex changes through multiple small patches
 4. **Handle failures gracefully** – Inspect error output to adjust context/line numbers
 
@@ -36,6 +36,6 @@ The `git_apply` tool enables precise, incremental file modifications by applying
 
 ### Error Recovery
 
-- **"corrupt patch at line X"** → Verify diff format and context line accuracy
-- **"patch does not apply"** → Check that target file state matches diff expectations
+- **"Failed to apply hunk"** → Verify diff format and context lines
+- **"Patch did not apply"** → Check that target file state matches diff expectations
 - Use `run_command` to inspect current file content before retrying with adjusted context

--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -305,7 +305,7 @@ export class ContainerManager {
     }
   }
 
-  async applyPatch(projectName, diff, options = {}) {
+  async applyDiff(projectName, diff, options = {}) {
     const containerName = `dockashell-${projectName}`;
     const timeoutMs = options.timeout || 30000;
     const startTime = Date.now();
@@ -321,7 +321,7 @@ export class ContainerManager {
       }
 
       const exec = await container.exec({
-        Cmd: ['bash', '-c', 'git apply --whitespace=fix -'],
+        Cmd: ['bash', '-c', 'aider --apply -'],
         AttachStdout: true,
         AttachStderr: true,
         AttachStdin: true,
@@ -339,7 +339,7 @@ export class ContainerManager {
       const stderrStream = new PassThrough();
       container.modem.demuxStream(stream, stdoutStream, stderrStream);
 
-      // Ensure diff ends with newline for git apply
+      // Ensure diff ends with newline for aider
       stream.end(diff.endsWith('\n') ? diff : diff + '\n');
 
       let output = '';
@@ -385,7 +385,7 @@ export class ContainerManager {
 
       await this.logger.logToolExecution(
         projectName,
-        'git_apply',
+        'apply_diff',
         { diff },
         {
           exitCode: result.exitCode,
@@ -407,7 +407,7 @@ export class ContainerManager {
       const duration = ((Date.now() - startTime) / 1000).toFixed(2);
       await this.logger.logToolExecution(
         projectName,
-        'git_apply',
+        'apply_diff',
         { diff },
         {
           exitCode: -1,

--- a/src/logger.js
+++ b/src/logger.js
@@ -40,8 +40,7 @@ export class Logger {
 
   async getTraceRecorder(projectName) {
     if (!this.traceRecorders.has(projectName)) {
-      const timeoutStr =
-        this._config?.logging?.traces?.session_timeout || '4h';
+      const timeoutStr = this._config?.logging?.traces?.session_timeout || '4h';
       const timeoutMs = parseDuration(timeoutStr) || 4 * 60 * 60 * 1000;
       this.traceRecorders.set(
         projectName,
@@ -141,10 +140,10 @@ export class Logger {
                 command: trace.command,
                 result: trace.result,
               };
-            } else if (trace.tool === 'git_apply') {
+            } else if (trace.tool === 'apply_diff') {
               return {
                 timestamp: trace.timestamp,
-                kind: 'git_apply',
+                kind: 'apply_diff',
                 diff: trace.diff,
                 result: trace.result,
               };
@@ -172,8 +171,8 @@ export class Logger {
           );
         } else if (type === 'command') {
           entries = entries.filter((e) => e.kind === 'command');
-        } else if (type === 'git_apply') {
-          entries = entries.filter((e) => e.kind === 'git_apply');
+        } else if (type === 'apply_diff') {
+          entries = entries.filter((e) => e.kind === 'apply_diff');
         } else {
           entries = entries.filter(
             (e) => e.kind === type || e.noteType === type

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -185,9 +185,9 @@ class DockashellServer {
       }
     );
 
-    // Git apply patch tool
+    // Diff apply tool via aider
     this.server.tool(
-      'git_apply',
+      'apply_diff',
       {
         project_name: z.string().describe('Name of the project'),
         diff: z.string().describe('Unified git diff to apply'),
@@ -205,12 +205,12 @@ class DockashellServer {
           // Ensure project exists
           await this.projectManager.loadProject(project_name);
 
-          const result = await this.containerManager.applyPatch(
+          const result = await this.containerManager.applyDiff(
             project_name,
             diff
           );
 
-          let response = `# Git Apply: ${project_name}\n\n`;
+          let response = `# Apply Diff: ${project_name}\n\n`;
           response += `**Exit Code:** ${result.exitCode}\n`;
           response += `**Success:** ${result.success ? '✅' : '❌'}\n\n`;
 
@@ -297,20 +297,20 @@ class DockashellServer {
               const typeLabel =
                 entry.kind === 'command'
                   ? 'COMMAND'
-                  : entry.kind === 'git_apply'
-                    ? 'GIT_APPLY'
+                  : entry.kind === 'apply_diff'
+                    ? 'APPLY_DIFF'
                     : (entry.noteType || entry.kind || 'UNKNOWN').toUpperCase();
 
               if (
                 selected.includes('exit_code') &&
-                (entry.kind === 'command' || entry.kind === 'git_apply') &&
+                (entry.kind === 'command' || entry.kind === 'apply_diff') &&
                 entry.result?.exitCode !== undefined
               ) {
                 meta.push(`exit_code=${entry.result.exitCode}`);
               }
               if (
                 selected.includes('duration') &&
-                (entry.kind === 'command' || entry.kind === 'git_apply') &&
+                (entry.kind === 'command' || entry.kind === 'apply_diff') &&
                 entry.result?.duration
               ) {
                 meta.push(`duration=${entry.result.duration}`);
@@ -330,7 +330,7 @@ class DockashellServer {
                   } else {
                     lines.push(entry.command);
                   }
-                } else if (entry.kind === 'git_apply') {
+                } else if (entry.kind === 'apply_diff') {
                   lines.push(entry.diff);
                 } else {
                   lines.push(entry.text);
@@ -339,7 +339,7 @@ class DockashellServer {
 
               if (
                 selected.includes('output') &&
-                (entry.kind === 'command' || entry.kind === 'git_apply') &&
+                (entry.kind === 'command' || entry.kind === 'apply_diff') &&
                 entry.result?.output
               ) {
                 lines.push('');

--- a/src/tui/entry-utils.js
+++ b/src/tui/entry-utils.js
@@ -191,7 +191,7 @@ export const buildEntryLines = (
         );
       }
     }
-  } else if (entry.kind === 'git_apply') {
+  } else if (entry.kind === 'apply_diff') {
     const result = entry.result || {};
     const exitCode = result.exitCode !== undefined ? result.exitCode : 'N/A';
     const duration = result.duration || 'N/A';
@@ -201,7 +201,7 @@ export const buildEntryLines = (
       type: 'header',
       icon: '🩹',
       timestamp: formatTimestamp(entry.timestamp),
-      typeText: `GIT_APPLY | Exit: ${exitCode} | ${duration}`,
+      typeText: `APPLY_DIFF | Exit: ${exitCode} | ${duration}`,
       typeColor,
     });
 

--- a/src/tui/read-traces.js
+++ b/src/tui/read-traces.js
@@ -70,10 +70,10 @@ export async function readTraceEntries(
           command: trace.command,
           result: trace.result,
         };
-      } else if (trace.tool === 'git_apply') {
+      } else if (trace.tool === 'apply_diff') {
         entry = {
           timestamp: trace.timestamp,
-          kind: 'git_apply',
+          kind: 'apply_diff',
           diff: trace.diff,
           result: trace.result,
         };

--- a/test/integration/test-mcp-tools.js
+++ b/test/integration/test-mcp-tools.js
@@ -135,25 +135,25 @@ async function testMCPTools() {
     );
   }
 
-  // Test 5: git_apply with nonexistent project
+  // Test 5: apply_diff with nonexistent project
   try {
-    console.log('5. Testing git_apply with nonexistent project...');
+    console.log('5. Testing apply_diff with nonexistent project...');
     const diff =
       'diff --git a/foo.txt b/foo.txt\nindex 0000000..e69de29 100644\n--- a/foo.txt\n+++ b/foo.txt\n@@\n+test\n';
-    const response = await runMCPCommand('git_apply', {
+    const response = await runMCPCommand('apply_diff', {
       project_name: 'missing',
       diff,
     });
     if (response.error || response.result?.isError) {
       console.log(
-        '✅ git_apply handled error:',
+        '✅ apply_diff handled error:',
         response.result?.content?.[0]?.text || response.error?.message
       );
     } else {
-      console.log('❌ git_apply should have failed for nonexistent project');
+      console.log('❌ apply_diff should have failed for nonexistent project');
     }
   } catch (error) {
-    console.log('✅ git_apply handled error gracefully:', error.message);
+    console.log('✅ apply_diff handled error gracefully:', error.message);
   }
 
   // Test 6: Stop project (should handle gracefully)

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -76,11 +76,11 @@ describe('Logger', () => {
     assert.ok(texts.includes('Second entry'));
   });
 
-  test('should log git_apply traces', async () => {
+  test('should log apply_diff traces', async () => {
     const diff = 'diff --git a/a b/a\n--- a/a\n+++ b/a\n@@\n-test\n+test2';
     await logger.logToolExecution(
       'test-project',
-      'git_apply',
+      'apply_diff',
       { diff },
       {
         exitCode: 1,
@@ -90,7 +90,7 @@ describe('Logger', () => {
     );
 
     const entries = await logger.readTraces('test-project', {
-      type: 'git_apply',
+      type: 'apply_diff',
       limit: 5,
     });
     assert.strictEqual(entries.length, 1);

--- a/test/read-traces.test.js
+++ b/test/read-traces.test.js
@@ -62,12 +62,12 @@ describe('read-traces helpers', () => {
     assert.strictEqual(currentEntries.length, 1);
   });
 
-  test('parses git_apply entries', async () => {
+  test('parses apply_diff entries', async () => {
     const current = getTraceFile('proj', 'current');
     await fs.ensureDir(path.dirname(current));
     const entry = {
       timestamp: new Date().toISOString(),
-      tool: 'git_apply',
+      tool: 'apply_diff',
       trace_type: 'execution',
       diff: 'diff --git a/a b/a',
       result: { exitCode: 0, duration: '0.1s' },
@@ -76,7 +76,7 @@ describe('read-traces helpers', () => {
 
     const entries = await readTraceEntries('proj', 10, 'current');
     assert.strictEqual(entries.length, 1);
-    assert.strictEqual(entries[0].kind, 'git_apply');
+    assert.strictEqual(entries[0].kind, 'apply_diff');
     assert.strictEqual(entries[0].diff, 'diff --git a/a b/a');
     assert.strictEqual(entries[0].result.exitCode, 0);
   });


### PR DESCRIPTION
## Summary
- replace `git_apply` tool with `apply_diff` using `aider --apply`
- update logging and trace parsing for new tool
- rename documentation to `apply-diff-tool.md`
- document Aider diff usage
- update tests and README for `apply_diff`

## Testing
- `npm test`
- `npm run lint`
