### PR TITLE
Improve trace session handling

### DIFF
--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -25,7 +25,6 @@ Trace entries capture tool activity and notes. Each includes:
 - `session_id` – current session identifier
 - `project_name` – project context
 - `timestamp` – ISO time string
-- `elapsed_ms` – milliseconds since session start
 - `tool` – component emitting the trace
 - `trace_type` – `execution`, `observation` or `decision`
 - Additional tool‑specific data (command, result, diff, etc.)

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -25,7 +25,6 @@ Trace entries capture tool activity and notes. Each includes:
 - `session_id` – current session identifier
 - `project_name` – project context
 - `timestamp` – ISO time string
-- `elapsed_ms` – milliseconds since session start
 - `tool` – component emitting the trace
 - `trace_type` – `execution`, `observation` or `decision`
 - Additional tool‑specific data (command, result, diff, etc.)


### PR DESCRIPTION
## Summary
- persist trace sessions across restarts and remove `elapsed_ms`
- refresh sessions in the TUI automatically
- update docs for revised trace format

## Testing
- `npm run lint --silent`
- `npm test --silent`
