### PR TITLE
Preserve traces across restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,10 @@ Agent traces are stored in `~/.dockashell/projects/{project-name}/traces/current
 Use `write_trace` to store notes and `read_traces` to query previous entries.
 
 Trace sessions rotate automatically when there are more than four hours between
-entries. The timeout can be changed in `~/.dockashell/config.json` using
-`logging.traces.session_timeout` (e.g. `"2h"`).
+entries. If DockaShell restarts within this window, the same `current.jsonl`
+file continues to be used so history remains visible in the TUI. The timeout can
+be changed in `~/.dockashell/config.json` using `logging.traces.session_timeout`
+(e.g. `"2h"`).
 
 ## 🔌 MCP Client Integration
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -15,7 +15,7 @@ System logs contain operational messages and error details that help developers 
 
 - **Path**: `~/.dockashell/projects/{project}/traces/current.jsonl`
 - **Format**: JSON Lines, one structured object per entry
-- **Session Rotation**: automatically rotates when no trace has been written for four hours (configurable via `logging.traces.session_timeout`)
+- **Session Rotation**: automatically rotates when no trace has been written for four hours (configurable via `logging.traces.session_timeout`). Sessions persist across restarts within this window so the `current.jsonl` file remains active.
 - Managed by `TraceRecorder` in `src/trace-recorder.js`
 - Accessed through the `Logger` facade (`src/logger.js`)
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -196,9 +196,12 @@ export class Logger {
   }
 
   async cleanup() {
+    const now = Date.now();
     for (const recorder of this.traceRecorders.values()) {
       try {
-        await recorder.close();
+        if (now - recorder.lastTraceTime > recorder.sessionTimeoutMs) {
+          await recorder.close();
+        }
       } catch (error) {
         systemLogger.warn('Failed to close trace recorder', {
           error: error.message,


### PR DESCRIPTION
## Summary
- only archive the current trace file if the session timeout has elapsed
- clarify in the docs that trace sessions persist across restarts within the timeout window

## Testing
- `npm test`
- `npm run lint`
