### PR TITLE
Cleanup unused config fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,17 @@ Trace sessions rotate automatically when there are more than four hours between
 entries. If DockaShell restarts within this window, the same `current.jsonl`
 file continues to be used so history remains visible in the TUI. The timeout can
 be changed in `~/.dockashell/config.json` using `logging.traces.session_timeout`
-(e.g. `"2h"`).
+(e.g. `"2h"`). The default configuration sets this to `"4h"`:
+
+```json
+{
+  "logging": {
+    "traces": {
+      "session_timeout": "4h"
+    }
+  }
+}
+```
 
 ## 🔌 MCP Client Integration
 
@@ -346,10 +356,7 @@ TUI settings in `~/.dockashell/config.json`:
 {
   "tui": {
     "display": {
-      "max_lines_per_entry": 5,
-      "max_entries": 100,
-      "show_icons": true,
-      "theme": "dark"
+      "max_entries": 100
     }
   }
 }

--- a/docs/default-image-implementation.md
+++ b/docs/default-image-implementation.md
@@ -46,6 +46,24 @@ npm run setup-examples     # Create example projects
 npm run setup-config       # Initialize ~/.dockashell
 ```
 
+Running `npm run setup-config` now creates a global `config.json` with TUI display
+settings and the `logging.traces.session_timeout` property:
+
+```json
+{
+  "tui": {
+    "display": {
+      "max_entries": 100
+    }
+  },
+  "logging": {
+    "traces": {
+      "session_timeout": "4h"
+    }
+  }
+}
+```
+
 ## 🔄 Project Configuration Changes
 
 ### Before (verbose)

--- a/scripts/setup-dockashell.js
+++ b/scripts/setup-dockashell.js
@@ -17,13 +17,18 @@ async function setupDockashell() {
   await fs.ensureDir(projectsDir);
   await fs.ensureDir(logsDir);
 
-  // Create global config
+  // Create global config matching src/config.js defaultConfig
   const globalConfigPath = path.join(configDir, 'config.json');
   const globalConfig = {
-    version: '1.0',
+    tui: {
+      display: {
+        max_entries: 100,
+      },
+    },
     logging: {
-      enabled: true,
-      directory: logsDir,
+      traces: {
+        session_timeout: '4h',
+      },
     },
   };
   await fs.writeJSON(globalConfigPath, globalConfig, { spaces: 2 });

--- a/src/config.js
+++ b/src/config.js
@@ -5,15 +5,7 @@ import os from 'os';
 const defaultConfig = {
   tui: {
     display: {
-      max_lines_per_entry: 5,
       max_entries: 100,
-      max_visible_entries: 10,
-      show_icons: true,
-      theme: 'dark',
-    },
-    projects: {
-      default: null,
-      recent: [],
     },
   },
   logging: {
@@ -35,11 +27,6 @@ export async function loadConfig() {
     const cfg = await fs.readJSON(configPath);
     if (!cfg.tui) cfg.tui = { ...defaultConfig.tui };
     if (!cfg.tui.display) cfg.tui.display = { ...defaultConfig.tui.display };
-    // Ensure max_visible_entries exists
-    if (!cfg.tui.display.max_visible_entries) {
-      cfg.tui.display.max_visible_entries =
-        defaultConfig.tui.display.max_visible_entries;
-    }
     if (!cfg.logging) cfg.logging = { ...defaultConfig.logging };
     if (!cfg.logging.traces)
       cfg.logging.traces = { ...defaultConfig.logging.traces };

--- a/src/project-manager.js
+++ b/src/project-manager.js
@@ -29,10 +29,15 @@ export class ProjectManager {
     const globalConfigPath = path.join(this.configDir, 'config.json');
     if (!(await fs.pathExists(globalConfigPath))) {
       const defaultConfig = {
-        version: '1.0',
+        tui: {
+          display: {
+            max_entries: 100,
+          },
+        },
         logging: {
-          enabled: true,
-          directory: path.join(this.configDir, 'logs'),
+          traces: {
+            session_timeout: '4h',
+          },
         },
       };
       await fs.writeJSON(globalConfigPath, defaultConfig, { spaces: 2 });

--- a/src/tui-launcher.js
+++ b/src/tui-launcher.js
@@ -16,11 +16,7 @@ const projectArg = program.args[0];
 
 const defaultTuiConfig = {
   display: {
-    max_lines_per_entry: 5,
     max_entries: 100,
-    max_visible_entries: 10,
-    show_icons: true,
-    theme: 'dark',
   },
 };
 

--- a/src/tui/LogViewer.js
+++ b/src/tui/LogViewer.js
@@ -114,7 +114,6 @@ export const LogViewer = ({ project, onBack, onExit, config }) => {
   const [buffer, setBuffer] = useState(null);
   const { stdout } = useStdout();
 
-  const maxLinesPerEntry = config?.display?.max_lines_per_entry || 10;
 
   // Keep refs synced with state for callbacks
   useEffect(() => {
@@ -209,9 +208,7 @@ export const LogViewer = ({ project, onBack, onExit, config }) => {
 
     const update = () => {
       const raw = buf.getTraces();
-      const prepared = raw.map((e) =>
-        prepareEntry(e, maxLinesPerEntry, terminalWidth)
-      );
+      const prepared = raw.map((e) => prepareEntry(e, null, terminalWidth));
 
       setEntries(prepared);
       if (prepared.length > 0) {
@@ -254,7 +251,7 @@ export const LogViewer = ({ project, onBack, onExit, config }) => {
     return () => {
       buf.close();
     };
-  }, [project, config, terminalHeight, terminalWidth, maxLinesPerEntry]);
+  }, [project, config, terminalHeight, terminalWidth]);
 
   // Input handling
   useInput((input, key) => {


### PR DESCRIPTION
## Summary
- remove unused TUI fields from global config
- drop references to `max_lines_per_entry`, `max_visible_entries`, `show_icons` and `theme`
- adjust setup script and project manager defaults
- update README and docs to match

## Testing
- `npm test`