### PR TITLE
Add write_file MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ Executes a shell command in the project container.
 **Arguments:** `{"project_name": "string", "patch": "string"}`
 Applies patches using the [OpenAI format](https://cookbook.openai.com/examples/gpt4-1_prompting_guide#appendix-generating-and-applying-file-diffs) inside the project container with context-based matching. More reliable than line-number based diffs for iterative edits.
 
+### `write_file`
+**Arguments:** `{"project_name": "string", "path": "string", "content": "string", "overwrite?": "boolean"}`
+Creates or overwrites a file inside the container. Intermediate directories are created automatically. Set `overwrite` to `true` to replace existing files (defaults to `false`).
+
 ### `project_status`
 **Arguments:** `{"project_name": "string"}`
 Returns detailed status information about the project container.

--- a/src/logger.js
+++ b/src/logger.js
@@ -147,6 +147,13 @@ export class Logger {
                 diff: trace.patch,
                 result: trace.result,
               };
+            } else if (trace.tool === 'write_file') {
+              return {
+                timestamp: trace.timestamp,
+                kind: 'write_file',
+                path: trace.path,
+                result: trace.result,
+              };
             } else if (trace.tool === 'write_trace') {
               return {
                 timestamp: trace.timestamp,
@@ -173,6 +180,8 @@ export class Logger {
           entries = entries.filter((e) => e.kind === 'command');
         } else if (type === 'apply_patch') {
           entries = entries.filter((e) => e.kind === 'apply_patch');
+        } else if (type === 'write_file') {
+          entries = entries.filter((e) => e.kind === 'write_file');
         } else {
           entries = entries.filter(
             (e) => e.kind === type || e.noteType === type

--- a/src/tui/FilterModal.js
+++ b/src/tui/FilterModal.js
@@ -9,6 +9,7 @@ export const FilterModal = ({ onClose, onApply, currentFilters }) => {
     { key: 'summary', label: 'Summary', color: 'green' },
     { key: 'command', label: 'Command', color: 'white' },
     { key: 'apply_patch', label: 'Apply Patch', color: 'cyan' },
+    { key: 'write_file', label: 'Write File', color: 'magenta' },
   ];
 
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -19,6 +20,7 @@ export const FilterModal = ({ onClose, onApply, currentFilters }) => {
       summary: true,
       command: true,
       apply_patch: true,
+      write_file: true,
     }
   );
 

--- a/src/tui/read-traces.js
+++ b/src/tui/read-traces.js
@@ -77,6 +77,13 @@ export async function readTraceEntries(
           patch: trace.patch,
           result: trace.result,
         };
+      } else if (trace.tool === 'write_file') {
+        entry = {
+          timestamp: trace.timestamp,
+          kind: 'write_file',
+          path: trace.path,
+          result: trace.result,
+        };
       } else if (trace.tool === 'write_trace') {
         entry = {
           timestamp: trace.timestamp,

--- a/test/entry-utils.test.js
+++ b/test/entry-utils.test.js
@@ -152,9 +152,11 @@ describe('detectTraceType', () => {
     const note = { kind: 'note', noteType: 'agent' };
     const patch = { kind: 'apply_patch', patch: 'patch' };
     const cmd = { kind: 'command', command: 'ls' };
+    const write = { kind: 'write_file', path: 'f' };
 
     assert.strictEqual(detectTraceType(note), 'agent');
     assert.strictEqual(detectTraceType(patch), 'apply_patch');
     assert.strictEqual(detectTraceType(cmd), 'command');
+    assert.strictEqual(detectTraceType(write), 'write_file');
   });
 });

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -97,4 +97,21 @@ describe('Logger', () => {
     assert.ok(entries[0].diff.startsWith('diff --git'));
     assert.strictEqual(entries[0].result.exitCode, 1);
   });
+
+  test('should log write_file traces', async () => {
+    await logger.logToolExecution(
+      'test-project',
+      'write_file',
+      { path: 'foo.txt', overwrite: true },
+      { exitCode: 0, duration: '0.1s', output: '' }
+    );
+
+    const entries = await logger.readTraces('test-project', {
+      type: 'write_file',
+      limit: 5,
+    });
+    assert.strictEqual(entries.length, 1);
+    assert.strictEqual(entries[0].path, 'foo.txt');
+    assert.strictEqual(entries[0].result.exitCode, 0);
+  });
 });


### PR DESCRIPTION
## Summary
- implement `write_file` method in container manager
- expose new `write_file` MCP tool
- log and parse `write_file` traces
- support `write_file` in read_traces and TUI
- document `write_file` tool
- test coverage for logger and trace utils

## Testing
- `npm test`