### PR TITLE
Centralize default configuration

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,19 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
-
-const defaultConfig = {
-  tui: {
-    display: {
-      max_entries: 100,
-    },
-  },
-  logging: {
-    traces: {
-      session_timeout: '4h',
-    },
-  },
-};
+import { defaultConfig } from './default-config.js';
 
 export async function loadConfig() {
   const configDir = path.join(os.homedir(), '.dockashell');

--- a/src/default-config.js
+++ b/src/default-config.js
@@ -1,0 +1,12 @@
+export const defaultConfig = {
+  tui: {
+    display: {
+      max_entries: 100,
+    },
+  },
+  logging: {
+    traces: {
+      session_timeout: '4h',
+    },
+  },
+};

--- a/src/project-manager.js
+++ b/src/project-manager.js
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
+import { defaultConfig } from './default-config.js';
 
 export class ProjectManager {
   constructor() {
@@ -28,18 +29,6 @@ export class ProjectManager {
     // Create global config if it doesn't exist
     const globalConfigPath = path.join(this.configDir, 'config.json');
     if (!(await fs.pathExists(globalConfigPath))) {
-      const defaultConfig = {
-        tui: {
-          display: {
-            max_entries: 100,
-          },
-        },
-        logging: {
-          traces: {
-            session_timeout: '4h',
-          },
-        },
-      };
       await fs.writeJSON(globalConfigPath, defaultConfig, { spaces: 2 });
     }
   }


### PR DESCRIPTION
## Summary
- share default configuration in `src/default-config.js`
- reference the shared config from `config.js` and `project-manager.js`

## Testing
- `npm test`