### PR TITLE
Refactor project name validation

### DIFF
--- a/src/project-manager.js
+++ b/src/project-manager.js
@@ -66,21 +66,7 @@ export class ProjectManager {
   }
 
   async loadProject(projectName) {
-    if (
-      !projectName ||
-      typeof projectName !== 'string' ||
-      projectName.trim() === ''
-    ) {
-      throw new Error('Project name must be a non-empty string');
-    }
-
-    // Sanitize project name to prevent path traversal
-    const sanitizedName = projectName.replace(/[^a-zA-Z0-9_-]/g, '');
-    if (sanitizedName !== projectName) {
-      throw new Error(
-        `Invalid project name '${projectName}'. Only alphanumeric characters, hyphens, and underscores are allowed.`
-      );
-    }
+    this.validateProjectName(projectName);
 
     const projectPath = path.join(this.projectsDir, projectName);
     const configPath = path.join(projectPath, 'config.json');

--- a/test/project-manager.test.js
+++ b/test/project-manager.test.js
@@ -98,12 +98,12 @@ describe('ProjectManager', () => {
 
     await assert.rejects(
       async () => await projectManager.loadProject('../../malicious'),
-      /Invalid project name/
+      /can only contain letters/
     );
 
     await assert.rejects(
       async () => await projectManager.loadProject('project with spaces'),
-      /Invalid project name/
+      /can only contain letters/
     );
   });
 


### PR DESCRIPTION
## Summary
- use `validateProjectName` inside `loadProject` to enforce name rules
- update tests to expect new validation message

## Testing
- `npm test`
- `npm run lint`
