### PR TITLE
Remove command blocklist features

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ DockaShell provides isolated, persistent Docker containers for AI agents to safe
 - **🚀 Persistent State**: Containers maintain state across command executions
 - **🌐 Port Mapping**: Easy web development with automatic port forwarding
 - **📁 Project Directory Mounting**: Seamless file access between host and container
-- **🛡️ Security Controls**: Configurable command blocking and timeouts
+- **🛡️ Security Controls**: Execution timeouts for commands
 - **📊 Command Logging**: Full audit trail of all executed commands
 - **🔧 MCP Integration**: Standard Model Context Protocol interface
 - **🐳 Default Development Image**: Pre-built Ubuntu 24.04 LTS with Node.js 20 LTS, Python 3, and essential CLI tools
@@ -150,8 +150,6 @@ Projects are configured in `~/.dockashell/projects/{project-name}/config.json`:
   "working_dir": "/workspace",
   "shell": "/bin/bash",
   "security": {
-    "restricted_mode": false,
-    "blocked_commands": ["rm -rf /", "sudo rm -rf"],
     "max_execution_time": 300
   }
 }
@@ -171,8 +169,6 @@ Note: The `image` field is optional - if omitted, projects will use the default 
 | `environment` | Environment variables | {} |
 | `working_dir` | Container working directory | "/workspace" |
 | `shell` | Default shell | "/bin/bash" |
-| `security.restricted_mode` | Enable security restrictions | false |
-| `security.blocked_commands` | Commands to block | [] |
 | `security.max_execution_time` | Command timeout (seconds) | 300 |
 
 ## 🔧 MCP Tools
@@ -243,15 +239,6 @@ read_traces("project", {search: "error"})
 - **Container Isolation**: Each project is completely isolated
 - **Non-privileged Execution**: Containers run without root access
 - **Audit Logging**: All commands logged with timestamps
-
-### Default Blocked Commands
-
-When `restricted_mode` is enabled:
-- `rm -rf /` - Recursive delete of root
-- `:(){ :|:& };:` - Fork bomb
-- `sudo rm -rf` - Privileged delete
-- `mkfs` - Format filesystem
-- `dd if=/dev/zero` - Zero out devices
 
 ## 📊 Logging
 

--- a/scripts/setup-dockashell.js
+++ b/scripts/setup-dockashell.js
@@ -61,8 +61,6 @@ async function setupDockashell() {
     working_dir: '/workspace',
     shell: '/bin/bash',
     security: {
-      restricted_mode: false,
-      blocked_commands: [],
       max_execution_time: 300,
     },
   };
@@ -96,8 +94,6 @@ async function setupDockashell() {
     working_dir: '/workspace',
     shell: '/bin/bash',
     security: {
-      restricted_mode: false,
-      blocked_commands: [],
       max_execution_time: 300,
     },
   };

--- a/scripts/setup/create-examples.js
+++ b/scripts/setup/create-examples.js
@@ -42,8 +42,6 @@ async function createExampleProjects() {
     working_dir: '/workspace',
     shell: '/bin/bash',
     security: {
-      restricted_mode: false,
-      blocked_commands: ['rm -rf /', 'sudo rm -rf', 'mkfs'],
       max_execution_time: 300,
     },
   };
@@ -81,8 +79,6 @@ async function createExampleProjects() {
     working_dir: '/workspace',
     shell: '/bin/bash',
     security: {
-      restricted_mode: false,
-      blocked_commands: ['rm -rf /', 'sudo passwd'],
       max_execution_time: 600,
     },
   };
@@ -121,8 +117,6 @@ async function createExampleProjects() {
     working_dir: '/workspace',
     shell: '/bin/bash',
     security: {
-      restricted_mode: false,
-      blocked_commands: [],
       max_execution_time: 300,
     },
   };

--- a/src/project-manager.js
+++ b/src/project-manager.js
@@ -111,10 +111,6 @@ export class ProjectManager {
         working_dir: config.working_dir || '/workspace',
         shell: config.shell || '/bin/bash',
         security: {
-          restricted_mode: config.security?.restricted_mode || false,
-          blocked_commands: Array.isArray(config.security?.blocked_commands)
-            ? config.security.blocked_commands
-            : [],
           max_execution_time:
             typeof config.security?.max_execution_time === 'number'
               ? config.security.max_execution_time

--- a/src/security.js
+++ b/src/security.js
@@ -1,14 +1,5 @@
 export class SecurityManager {
-  constructor() {
-    this.DEFAULT_BLOCKED_COMMANDS = [
-      'rm -rf /',
-      ':(){ :|:& };:', // fork bomb
-      'sudo rm -rf',
-      'mkfs',
-      'dd if=/dev/zero',
-      'sudo passwd',
-    ];
-  }
+  constructor() {}
 
   validateCommand(command, projectConfig) {
     if (!command || typeof command !== 'string' || command.trim() === '') {
@@ -19,57 +10,9 @@ export class SecurityManager {
       throw new Error('Invalid project configuration');
     }
 
-    // If restricted mode is enabled, apply security checks
-    if (projectConfig.security?.restricted_mode) {
-      const blockedCommands = Array.isArray(
-        projectConfig.security.blocked_commands
-      )
-        ? projectConfig.security.blocked_commands
-        : this.DEFAULT_BLOCKED_COMMANDS;
-
-      if (this.isBlocked(command, blockedCommands)) {
-        throw new Error(`Command blocked by security policy: ${command}`);
-      }
-    }
+    // Command validation can be extended if needed
 
     return true;
-  }
-
-  isBlocked(command, blockedCommands) {
-    if (!Array.isArray(blockedCommands)) {
-      return false;
-    }
-
-    const normalizedCommand = command.trim();
-
-    return blockedCommands.some((blocked) => {
-      if (!blocked || typeof blocked !== 'string') {
-        return false;
-      }
-
-      const normalizedBlocked = blocked.toLowerCase();
-
-      // Exact match
-      if (normalizedCommand === normalizedBlocked) {
-        return true;
-      }
-
-      // Check if command starts with blocked pattern
-      if (normalizedCommand.startsWith(normalizedBlocked)) {
-        return true;
-      }
-
-      // Check for pattern within command (with word boundaries)
-      try {
-        const regex = new RegExp(
-          `\\b${normalizedBlocked.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`
-        );
-        return regex.test(normalizedCommand);
-      } catch {
-        // If regex fails, fall back to simple string matching
-        return normalizedCommand.includes(normalizedBlocked);
-      }
-    });
   }
 
   getMaxExecutionTime(projectConfig) {
@@ -91,4 +34,9 @@ export class SecurityManager {
    * Get default security settings
    * @returns {Object} Default security configuration
    */
+  getDefaultSecuritySettings() {
+    return {
+      max_execution_time: 300,
+    };
+  }
 }

--- a/test/integration/test-error-handling.js
+++ b/test/integration/test-error-handling.js
@@ -48,28 +48,7 @@ async function testErrorHandling() {
     console.log(`  ✅ Null config: ${error.message}`);
   }
 
-  // Test security with restricted mode
-  console.log('\n3. Testing security restrictions:');
-  const restrictedConfig = {
-    security: {
-      restricted_mode: true,
-      blocked_commands: ['rm -rf /'],
-    },
-  };
-
-  try {
-    server.securityManager.validateCommand('rm -rf /', restrictedConfig);
-    console.log('  ❌ Blocked command should fail');
-  } catch (error) {
-    console.log(`  ✅ Blocked command: ${error.message}`);
-  }
-
-  try {
-    server.securityManager.validateCommand('ls -la', restrictedConfig);
-    console.log('  ✅ Safe command passed validation');
-  } catch (error) {
-    console.log(`  ❌ Safe command failed: ${error.message}`);
-  }
+  // Security checks removed; containers are isolated
 
   // Test container operations timeout handling
   console.log('\n4. Testing container operations:');

--- a/test/project-manager.test.js
+++ b/test/project-manager.test.js
@@ -78,8 +78,6 @@ describe('ProjectManager', () => {
     assert.strictEqual(loadedConfig.shell, '/bin/bash');
 
     // Verify security defaults
-    assert.strictEqual(loadedConfig.security.restricted_mode, false);
-    assert.ok(Array.isArray(loadedConfig.security.blocked_commands));
     assert.strictEqual(loadedConfig.security.max_execution_time, 300);
   });
 

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -16,7 +16,7 @@ describe('SecurityManager', () => {
   test('should validate safe commands with project config', () => {
     const projectConfig = {
       name: 'test-project',
-      security: { restricted_mode: false },
+      security: {},
     };
     const safeCommands = [
       'ls -la',
@@ -27,54 +27,6 @@ describe('SecurityManager', () => {
     ];
 
     safeCommands.forEach((cmd) => {
-      assert.doesNotThrow(() =>
-        securityManager.validateCommand(cmd, projectConfig)
-      );
-    });
-  });
-
-  test('should block dangerous commands in restricted mode', () => {
-    const projectConfig = {
-      name: 'test-project',
-      security: {
-        restricted_mode: true,
-        blocked_commands: [
-          'rm -rf /',
-          'sudo rm -rf',
-          'dd if=/dev/zero',
-          'format c:',
-          'del /f /s /q',
-        ],
-      },
-    };
-    const dangerousCommands = [
-      'rm -rf /',
-      'sudo rm -rf *',
-      'dd if=/dev/zero of=/dev/sda',
-      'format c:',
-      'del /f /s /q c:\\*',
-    ];
-
-    dangerousCommands.forEach((cmd) => {
-      assert.throws(
-        () => securityManager.validateCommand(cmd, projectConfig),
-        /Command blocked by security policy/
-      );
-    });
-  });
-
-  test('should allow dangerous commands in non-restricted mode', () => {
-    const projectConfig = {
-      name: 'test-project',
-      security: { restricted_mode: false },
-    };
-    const commands = [
-      'rm -rf /tmp/somefile',
-      'sudo apt update',
-      'dd if=input.txt of=output.txt',
-    ];
-
-    commands.forEach((cmd) => {
       assert.doesNotThrow(() =>
         securityManager.validateCommand(cmd, projectConfig)
       );
@@ -127,5 +79,12 @@ describe('SecurityManager', () => {
     assert.doesNotThrow(() =>
       securityManager.validateCommand('echo hello', projectConfig)
     );
+  });
+
+  test('should return default security settings', () => {
+    const defaults = securityManager.getDefaultSecuritySettings();
+    assert.deepStrictEqual(defaults, {
+      max_execution_time: 300,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- drop `blocked_commands` and `restricted_mode` options
- simplify `SecurityManager` and related tests
- update example configs and README documentation

## Testing
- `npm test`
- `npm run lint`
- `npm run test:integration`