### PR TITLE
Add reusable trace path helpers

### DIFF
--- a/src/trace-recorder.js
+++ b/src/trace-recorder.js
@@ -1,19 +1,17 @@
 import fs from 'fs-extra';
 import path from 'path';
-import os from 'os';
+import {
+  getProjectTraceDir,
+  getCurrentTraceFile,
+  getSessionsDir,
+} from './tui/trace-paths.js';
 
 export class TraceRecorder {
   constructor(projectName, sessionTimeoutMs = 4 * 60 * 60 * 1000) {
     this.projectName = projectName;
-    this.baseDir = path.join(
-      os.homedir(),
-      '.dockashell',
-      'projects',
-      projectName,
-      'traces'
-    );
-    this.currentFile = path.join(this.baseDir, 'current.jsonl');
-    this.sessionsDir = path.join(this.baseDir, 'sessions');
+    this.baseDir = getProjectTraceDir(projectName);
+    this.currentFile = getCurrentTraceFile(projectName);
+    this.sessionsDir = getSessionsDir(projectName);
     this.sessionId = this.generateSessionId();
     this.sessionStart = Date.now();
     this.sessionTimeoutMs = sessionTimeoutMs;

--- a/src/tui/read-traces.js
+++ b/src/tui/read-traces.js
@@ -1,30 +1,16 @@
 import fs from 'fs-extra';
 import path from 'path';
-import os from 'os';
 import { parseTraceLines } from '../trace-utils.js';
+import { getCurrentTraceFile, getSessionsDir } from './trace-paths.js';
 
 export function getTraceFile(projectName, session = 'current') {
-  const base = path.join(
-    os.homedir(),
-    '.dockashell',
-    'projects',
-    projectName,
-    'traces'
-  );
   return session === 'current'
-    ? path.join(base, 'current.jsonl')
-    : path.join(base, 'sessions', `${session}.jsonl`);
+    ? getCurrentTraceFile(projectName)
+    : path.join(getSessionsDir(projectName), `${session}.jsonl`);
 }
 
 export async function listSessions(projectName) {
-  const dir = path.join(
-    os.homedir(),
-    '.dockashell',
-    'projects',
-    projectName,
-    'traces',
-    'sessions'
-  );
+  const dir = getSessionsDir(projectName);
 
   if (!(await fs.pathExists(dir))) {
     return ['current'];

--- a/src/tui/trace-buffer.js
+++ b/src/tui/trace-buffer.js
@@ -1,8 +1,7 @@
 import EventEmitter from 'events';
 import chokidar from 'chokidar';
-import path from 'path';
-import os from 'os';
 import { listSessions, readTraceEntries, getTraceFile } from './read-traces.js';
+import { getSessionsDir } from './trace-paths.js';
 
 export class TraceBuffer extends EventEmitter {
   constructor(projectName, maxEntries = 100) {
@@ -63,14 +62,7 @@ export class TraceBuffer extends EventEmitter {
   }
 
   async watch() {
-    const sessionsDir = path.join(
-      os.homedir(),
-      '.dockashell',
-      'projects',
-      this.projectName,
-      'traces',
-      'sessions'
-    );
+    const sessionsDir = getSessionsDir(this.projectName);
     const currentFile = getTraceFile(this.projectName, 'current');
 
     this.sessionWatcher = chokidar.watch(sessionsDir, { ignoreInitial: true });

--- a/src/tui/trace-paths.js
+++ b/src/tui/trace-paths.js
@@ -1,0 +1,20 @@
+import path from 'path';
+import os from 'os';
+
+export function getProjectTraceDir(projectName) {
+  return path.join(
+    os.homedir(),
+    '.dockashell',
+    'projects',
+    projectName,
+    'traces'
+  );
+}
+
+export function getCurrentTraceFile(projectName) {
+  return path.join(getProjectTraceDir(projectName), 'current.jsonl');
+}
+
+export function getSessionsDir(projectName) {
+  return path.join(getProjectTraceDir(projectName), 'sessions');
+}


### PR DESCRIPTION
## Summary
- centralize trace path computation with `src/tui/trace-paths.js`
- refactor recorder and TUI helpers to use the new functions

## Testing
- `npm test`