### PR TITLE
Organize tests by src subfolder

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "start": "node src/mcp/mcp-server.js",
-    "test": "node --test test/*.test.js",
+    "test": "node --test test/**/*.test.js",
     "test:integration": "node test/integration/test-*.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/test/core/project-manager.test.js
+++ b/test/core/project-manager.test.js
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
-import { ProjectManager } from '../src/core/project-manager.js';
+import { ProjectManager } from '../../src/core/project-manager.js';
 import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';

--- a/test/core/security.test.js
+++ b/test/core/security.test.js
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach } from 'node:test';
 import assert from 'node:assert';
-import { SecurityManager } from '../src/core/security.js';
+import { SecurityManager } from '../../src/core/security.js';
 
 describe('SecurityManager', () => {
   let securityManager;

--- a/test/tui/closest-timestamp.test.js
+++ b/test/tui/closest-timestamp.test.js
@@ -1,6 +1,6 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert';
-import { findClosestTimestamp } from '../src/tui/entry-utils.js';
+import { findClosestTimestamp } from '../../src/tui/entry-utils.js';
 
 describe('findClosestTimestamp', () => {
   test('finds exact timestamp match', () => {

--- a/test/tui/entry-utils.test.js
+++ b/test/tui/entry-utils.test.js
@@ -5,7 +5,7 @@ import {
   formatTimestamp,
   prepareEntry,
   detectTraceType,
-} from '../src/tui/entry-utils.js';
+} from '../../src/tui/entry-utils.js';
 
 const sampleCommand = {
   kind: 'command',

--- a/test/tui/line-formatter.test.js
+++ b/test/tui/line-formatter.test.js
@@ -5,7 +5,7 @@ import {
   formatMultilineText,
   truncateText,
   formatCommandOutput,
-} from '../src/tui/line-formatter.js';
+} from '../../src/tui/line-formatter.js';
 
 describe('wrapText', () => {
   test('wraps long text to specified width', () => {

--- a/test/tui/log-viewer-utils.test.js
+++ b/test/tui/log-viewer-utils.test.js
@@ -1,6 +1,6 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert';
-import { getEntryHeight } from '../src/tui/LogViewer.js';
+import { getEntryHeight } from '../../src/tui/LogViewer.js';
 
 const ensureVisible = (entries, terminalHeight, scrollOffset, index) => {
   if (entries.length === 0) return scrollOffset;

--- a/test/tui/read-traces.test.js
+++ b/test/tui/read-traces.test.js
@@ -7,7 +7,7 @@ import {
   readTraceEntries,
   listSessions,
   getTraceFile,
-} from '../src/tui/read-traces.js';
+} from '../../src/tui/read-traces.js';
 
 describe('read-traces helpers', () => {
   let tmpHome;

--- a/test/tui/trace-buffer.test.js
+++ b/test/tui/trace-buffer.test.js
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
-import { TraceBuffer } from '../src/tui/trace-buffer.js';
+import { TraceBuffer } from '../../src/tui/trace-buffer.js';
 
 // Create a simple manual mock for testing
 let mockListSessions = null;
@@ -8,7 +8,7 @@ let mockReadTraceEntries = null;
 let mockGetTraceFile = null;
 
 // Override the import to use our mocks
-const _originalImport = await import('../src/tui/read-traces.js');
+const _originalImport = await import('../../src/tui/read-traces.js');
 const mockReadTraces = {
   listSessions: (...args) => mockListSessions(...args),
   readTraceEntries: (...args) => mockReadTraceEntries(...args),

--- a/test/utils/logger.test.js
+++ b/test/utils/logger.test.js
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
-import { Logger } from '../src/utils/logger.js';
+import { Logger } from '../../src/utils/logger.js';
 import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';

--- a/test/utils/system-logger.test.js
+++ b/test/utils/system-logger.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
-import { SystemLogger } from '../src/utils/system-logger.js';
+import { SystemLogger } from '../../src/utils/system-logger.js';
 
 describe('SystemLogger', () => {
   let tmpDir;

--- a/test/utils/trace-recorder.test.js
+++ b/test/utils/trace-recorder.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
-import { TraceRecorder } from '../src/utils/trace-recorder.js';
+import { TraceRecorder } from '../../src/utils/trace-recorder.js';
 
 describe('TraceRecorder', () => {
   let tmpHome;

--- a/test/utils/trace-utils.test.js
+++ b/test/utils/trace-utils.test.js
@@ -1,6 +1,6 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert';
-import { parseTraceLine, parseTraceLines } from '../src/utils/trace-utils.js';
+import { parseTraceLine, parseTraceLines } from '../../src/utils/trace-utils.js';
 
 describe('trace-utils', () => {
   test('parseTraceLine handles known tools', () => {


### PR DESCRIPTION
## Summary
- move unit tests into folders that mirror `src`
- update imports in tests for new locations
- update npm test script to run recursively

## Testing
- `npm test`