### PR TITLE
Refactor trace buffer with ring buffer backend

### DIFF
--- a/src/tui/views/log-viewer/LogViewer.js
+++ b/src/tui/views/log-viewer/LogViewer.js
@@ -319,17 +319,15 @@ const LogViewerInner = ({ project, onBack, onExit, config }) => {
     setBuffer(buf);
 
     const update = () => {
-      const raw = buf.getTraces();
-      const prepared = raw.map((e) => prepareEntry(e, null, terminalWidth));
+      const allRaw = buf.getTraces();
+      const preparedAll = allRaw.map((e) => prepareEntry(e, null, terminalWidth));
 
-      const filtered = prepared.filter((entry) => {
-        const traceType = entry.traceType || 'unknown';
-        return filtersRef.current[traceType] !== false;
-      });
+      const filteredRaw = buf.getTraces({ filters: filtersRef.current });
+      const filtered = filteredRaw.map((e) => prepareEntry(e, null, terminalWidth));
 
       entriesRef.current.clear();
-      prepared.forEach((e) => entriesRef.current.push(e));
-      pendingRef.current += prepared.length;
+      preparedAll.forEach((e) => entriesRef.current.push(e));
+      pendingRef.current += preparedAll.length;
       if (pendingRef.current >= flushThreshold) {
         pendingRef.current = 0;
         setRenderTick((t) => t + 1);

--- a/test/tui/trace-buffer.test.js
+++ b/test/tui/trace-buffer.test.js
@@ -41,7 +41,8 @@ const PatchedTraceBuffer = class extends OriginalTraceBuffer {
     allTraces.sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
 
     // Keep only the most recent entries
-    this.entries = allTraces.slice(-this.maxEntries);
+    this.buffer.clear();
+    allTraces.slice(-this.maxEntries).forEach((t) => this.buffer.push(t));
   }
 };
 


### PR DESCRIPTION
## Summary
- refactor `TraceBuffer` to store entries in a `RingBuffer`
- expose filtering and search via `getTraces`
- adjust log viewer update logic to query filtered traces
- update trace buffer tests for new internal structure

## Testing
- `npm test`