### PR TITLE
Refactor LogViewer state into custom hooks

### DIFF
--- a/src/tui/hooks/useAutoScroll.js
+++ b/src/tui/hooks/useAutoScroll.js
@@ -1,0 +1,21 @@
+import { useRef, useState, useEffect } from 'react';
+
+export const useAutoScroll = () => {
+  const [autoScroll, setAutoScroll] = useState(true);
+  const autoScrollRef = useRef(true);
+
+  useEffect(() => {
+    autoScrollRef.current = autoScroll;
+  }, [autoScroll]);
+
+  const updateAutoScrollState = (index, total) => {
+    const threshold = 5;
+    if (total - index > threshold) {
+      setAutoScroll(false);
+    } else if (index >= total - 1) {
+      setAutoScroll(true);
+    }
+  };
+
+  return { autoScroll, setAutoScroll, autoScrollRef, updateAutoScrollState };
+};

--- a/src/tui/hooks/useFilters.js
+++ b/src/tui/hooks/useFilters.js
@@ -1,0 +1,23 @@
+import { useState, useRef, useEffect } from 'react';
+import { DEFAULT_FILTERS } from '../utils/entry-utils.js';
+
+export const useFilters = () => {
+  const [filters, setFilters] = useState(DEFAULT_FILTERS);
+  const [lastFilterState, setLastFilterState] = useState(DEFAULT_FILTERS);
+  const [showFilterModal, setShowFilterModal] = useState(false);
+  const filtersRef = useRef(filters);
+
+  useEffect(() => {
+    filtersRef.current = filters;
+  }, [filters]);
+
+  return {
+    filters,
+    setFilters,
+    lastFilterState,
+    setLastFilterState,
+    showFilterModal,
+    setShowFilterModal,
+    filtersRef,
+  };
+};

--- a/src/tui/hooks/useSelection.js
+++ b/src/tui/hooks/useSelection.js
@@ -1,0 +1,63 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+
+export const useSelection = (entries = []) => {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const selectedIndexRef = useRef(0);
+  const [scrollOffset, setScrollOffset] = useState(0);
+  const [detailsViewIndex, setDetailsViewIndex] = useState(null);
+  const detailsViewRef = useRef(null);
+  const selectedTimestampRef = useRef(null);
+  const detailsTimestampRef = useRef(null);
+  const [selectionBeforeFilter, setSelectionBeforeFilter] = useState(null);
+
+  useEffect(() => {
+    selectedIndexRef.current = selectedIndex;
+    selectedTimestampRef.current = entries[selectedIndex]?.entry.timestamp || null;
+  }, [selectedIndex, entries]);
+
+  useEffect(() => {
+    detailsViewRef.current = detailsViewIndex;
+    if (detailsViewIndex !== null) {
+      detailsTimestampRef.current = entries[detailsViewIndex]?.entry.timestamp || null;
+    }
+  }, [detailsViewIndex, entries]);
+
+  const ensureVisible = useCallback(
+    (index, entries, terminalHeight, getEntryHeight) => {
+      if (entries.length === 0) return;
+      let offset = scrollOffset;
+      if (index < offset) {
+        offset = index;
+      } else {
+        const availableHeight = terminalHeight - 3;
+        let height = 0;
+        for (let i = index; i >= offset; i--) {
+          height += getEntryHeight(entries[i], i === index);
+          if (height > availableHeight) {
+            offset = i + 1;
+            break;
+          }
+        }
+      }
+      offset = Math.min(Math.max(offset, 0), entries.length - 1);
+      setScrollOffset(offset);
+    },
+    [scrollOffset]
+  );
+
+  return {
+    selectedIndex,
+    setSelectedIndex,
+    selectedIndexRef,
+    selectedTimestampRef,
+    scrollOffset,
+    setScrollOffset,
+    detailsViewIndex,
+    setDetailsViewIndex,
+    detailsViewRef,
+    detailsTimestampRef,
+    selectionBeforeFilter,
+    setSelectionBeforeFilter,
+    ensureVisible,
+  };
+};

--- a/src/tui/hooks/useTerminalSize.js
+++ b/src/tui/hooks/useTerminalSize.js
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react';
+import { useStdout } from 'ink';
+
+export const useTerminalSize = () => {
+  const { stdout } = useStdout();
+  const [terminalHeight, setTerminalHeight] = useState(20);
+  const [terminalWidth, setTerminalWidth] = useState(80);
+
+  useEffect(() => {
+    const updateTerminalSize = () => {
+      if (stdout?.rows) {
+        setTerminalHeight(stdout.rows);
+      } else if (process.stdout?.rows) {
+        setTerminalHeight(process.stdout.rows);
+      } else {
+        setTerminalHeight(24);
+      }
+
+      if (stdout?.columns) {
+        setTerminalWidth(stdout.columns);
+      } else if (process.stdout?.columns) {
+        setTerminalWidth(process.stdout.columns);
+      } else {
+        setTerminalWidth(80);
+      }
+    };
+
+    updateTerminalSize();
+    process.stdout.on('resize', updateTerminalSize);
+    return () => process.stdout.off('resize', updateTerminalSize);
+  }, [stdout]);
+
+  return { terminalHeight, terminalWidth };
+};

--- a/src/tui/hooks/useTraceBuffer.js
+++ b/src/tui/hooks/useTraceBuffer.js
@@ -1,0 +1,9 @@
+import { useState } from 'react';
+
+export const useTraceBuffer = () => {
+  const [buffer, setBuffer] = useState(null);
+  const [entries, setEntries] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  return { buffer, setBuffer, entries, setEntries, loading, setLoading };
+};


### PR DESCRIPTION
## Summary
- add new hooks for trace buffer, terminal size, filter state, auto-scroll, and selection handling
- refactor `LogViewer` to use new hooks and clean up local state logic

## Testing
- `npm test`