### PR TITLE
Implement centralized TextLayout helper

### DIFF
--- a/src/tui/utils/entry-utils.js
+++ b/src/tui/utils/entry-utils.js
@@ -3,6 +3,7 @@ import {
   truncateText,
   formatCommandOutput,
 } from './line-formatter.js';
+import { TextLayout } from './text-layout.js';
 
 export const formatTimestamp = (timestamp) => {
   if (!timestamp) return 'No timestamp';
@@ -136,16 +137,16 @@ export const createHeaderLine = (entry, traceType, typeText) => ({
 });
 
 // Helper to append formatted output lines if present
-export const appendOutputLines = (lines, output, contentWidth, maxLines) => {
+export const appendOutputLines = (lines, output, layout, maxLines) => {
   if (!output || !output.trim()) return;
   lines.push({
     type: 'separator',
-    text: '─'.repeat(Math.min(contentWidth, 60)),
+    text: layout.createSeparator(),
   });
 
   const outputLines = formatCommandOutput(
     output.trim(),
-    contentWidth,
+    layout.contentWidth,
     maxLines - lines.length
   );
   outputLines.forEach((line) => lines.push({ type: 'output', text: line }));
@@ -161,7 +162,8 @@ export const buildEntryLines = (
   const lines = [];
 
   // Calculate available width for content
-  const contentAvailableWidth = Math.max(40, terminalWidth - 10); // Leave some margin
+  const layout = new TextLayout(terminalWidth);
+  const contentAvailableWidth = layout.contentWidth; // Leave some margin
 
   // Always use 2 lines for list view (compact mode)
   const _effectiveMaxLines = compact ? 2 : maxLines;
@@ -261,12 +263,7 @@ export const buildEntryLines = (
           });
         }
         if (showOutput) {
-          appendOutputLines(
-            lines,
-            result.output,
-            contentAvailableWidth,
-            maxLines
-          );
+          appendOutputLines(lines, result.output, layout, maxLines);
         }
       }
       break;
@@ -310,12 +307,7 @@ export const buildEntryLines = (
           });
         });
         if (showOutput) {
-          appendOutputLines(
-            lines,
-            result.output,
-            contentAvailableWidth,
-            maxLines
-          );
+          appendOutputLines(lines, result.output, layout, maxLines);
         }
       }
       break;
@@ -350,7 +342,7 @@ export const buildEntryLines = (
       if (content && !compact) {
         lines.push({
           type: 'separator',
-          text: '─'.repeat(Math.min(contentAvailableWidth, 60)),
+          text: layout.createSeparator(),
         });
         const contentLines = formatMultilineText(
           content,
@@ -380,12 +372,7 @@ export const buildEntryLines = (
       }
 
       if (showOutput) {
-        appendOutputLines(
-          lines,
-          result.output,
-          contentAvailableWidth,
-          maxLines
-        );
+        appendOutputLines(lines, result.output, layout, maxLines);
       }
       break;
     }

--- a/src/tui/utils/line-formatter.js
+++ b/src/tui/utils/line-formatter.js
@@ -2,6 +2,10 @@
  * Line formatting utilities for consistent text rendering
  */
 
+import { ELLIPSIS_LENGTH } from './text-layout.js';
+
+const ELLIPSIS = '.'.repeat(ELLIPSIS_LENGTH);
+
 /**
  * Wrap text to fit within a specified width
  * @param {string} text - Text to wrap
@@ -106,10 +110,11 @@ export const formatMultilineText = (
   // Add truncation indicator if needed
   if (lines.length === maxLines && lines.length < inputLines.length) {
     const lastLine = lines[lines.length - 1];
-    if (lastLine.length > width - 3) {
-      lines[lines.length - 1] = lastLine.substring(0, width - 3) + '...';
+    const cutoff = width - ELLIPSIS_LENGTH;
+    if (lastLine.length > cutoff) {
+      lines[lines.length - 1] = lastLine.substring(0, cutoff) + ELLIPSIS;
     } else {
-      lines[lines.length - 1] = lastLine + '...';
+      lines[lines.length - 1] = lastLine + ELLIPSIS;
     }
   }
 
@@ -124,11 +129,11 @@ export const formatMultilineText = (
  */
 export const truncateText = (text, width) => {
   if (!text) return '';
-  if (width <= 3) return '...';
+  if (width <= ELLIPSIS_LENGTH) return ELLIPSIS;
   if (text.length < width) return text;
 
   // Ensure we have room for ellipsis
-  return text.substring(0, Math.max(0, width - 3)) + '...';
+  return text.substring(0, Math.max(0, width - ELLIPSIS_LENGTH)) + ELLIPSIS;
 };
 
 /**

--- a/src/tui/utils/text-layout.js
+++ b/src/tui/utils/text-layout.js
@@ -1,0 +1,68 @@
+export const ELLIPSIS_LENGTH = 3;
+export const DEFAULT_MAX_SEPARATOR_WIDTH = 60;
+export const MIN_CONTENT_WIDTH = 40;
+
+export class TextLayout {
+  constructor(terminalWidth) {
+    this.terminalWidth = terminalWidth;
+    this.contentWidth = Math.max(MIN_CONTENT_WIDTH, terminalWidth - 10);
+  }
+
+  wrap(text, options = {}) {
+    const width = options.width || this.contentWidth;
+    const prefix = options.prefix || '';
+    if (!text || width <= 0) return [];
+
+    const lines = [];
+    const words = text.split(/\s+/);
+    let currentLine = '';
+
+    for (const word of words) {
+      if (word.length > width) {
+        if (currentLine) {
+          lines.push(currentLine);
+          currentLine = '';
+        }
+        let lastChunk = '';
+        for (let i = 0; i < word.length; i += width) {
+          const chunk = word.slice(i, Math.min(i + width, word.length));
+          const fullLine = (lines.length > 0 ? prefix : '') + chunk;
+          lines.push(fullLine);
+          lastChunk = chunk;
+        }
+        const lastLineLength =
+          (lines.length > 0 ? prefix.length : 0) + lastChunk.length;
+        if (lastLineLength < width) {
+          currentLine = lines.pop();
+        }
+        continue;
+      }
+      const testLine = currentLine ? currentLine + ' ' + word : word;
+      if (testLine.length > width) {
+        lines.push(currentLine);
+        currentLine = prefix + word;
+      } else {
+        currentLine = testLine;
+      }
+    }
+
+    if (currentLine) {
+      lines.push(currentLine);
+    }
+
+    return lines.length > 0 ? lines : [''];
+  }
+
+  truncate(text, width = this.contentWidth) {
+    const ellipsis = '.'.repeat(ELLIPSIS_LENGTH);
+    if (!text) return '';
+    if (width <= ELLIPSIS_LENGTH) return ellipsis;
+    if (text.length < width) return text;
+    return text.substring(0, Math.max(0, width - ELLIPSIS_LENGTH)) + ellipsis;
+  }
+
+  createSeparator(width = this.contentWidth) {
+    const sepWidth = Math.min(width, DEFAULT_MAX_SEPARATOR_WIDTH);
+    return '─'.repeat(sepWidth);
+  }
+}

--- a/test/tui/text-layout.test.js
+++ b/test/tui/text-layout.test.js
@@ -1,0 +1,34 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import {
+  TextLayout,
+  MIN_CONTENT_WIDTH,
+  DEFAULT_MAX_SEPARATOR_WIDTH,
+  ELLIPSIS_LENGTH,
+} from '../../src/tui/utils/text-layout.js';
+
+describe('TextLayout', () => {
+  test('content width uses minimum for very narrow terminals', () => {
+    const layout = new TextLayout(20);
+    assert.strictEqual(layout.contentWidth, MIN_CONTENT_WIDTH);
+  });
+
+  test('wrap returns empty array for empty text', () => {
+    const layout = new TextLayout(80);
+    assert.deepStrictEqual(layout.wrap(''), []);
+  });
+
+  test('truncate handles widths shorter than ellipsis', () => {
+    const layout = new TextLayout(80);
+    const result = layout.truncate('hello', ELLIPSIS_LENGTH - 1);
+    assert.strictEqual(result, '.'.repeat(ELLIPSIS_LENGTH));
+  });
+
+  test('createSeparator caps length to default max', () => {
+    const layout = new TextLayout(200);
+    assert.strictEqual(
+      layout.createSeparator().length,
+      DEFAULT_MAX_SEPARATOR_WIDTH
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `TextLayout` utility with constants for ellipsis, separator width and minimum content width
- use constants in `line-formatter` and `entry-utils`
- update entry utils to rely on `TextLayout` for separator creation and content width
- add unit tests for `TextLayout` edge cases

## Testing
- `npm test`