### PR TITLE
Centralize UI constants

### DIFF
--- a/src/constants/ui.js
+++ b/src/constants/ui.js
@@ -1,0 +1,38 @@
+export const TRACE_TYPES = /** @type {const} */ ({
+  COMMAND: 'command',
+  APPLY_PATCH: 'apply_patch',
+  WRITE_FILE: 'write_file',
+  USER: 'user',
+  AGENT: 'agent',
+  SUMMARY: 'summary',
+  NOTE: 'note',
+  UNKNOWN: 'unknown'
+});
+
+export const TRACE_ICONS = /** @type {const} */ ({
+  command: '💻',
+  apply_patch: '🩹',
+  write_file: '📄',
+  user: '👤',
+  agent: '🤖',
+  summary: '📝',
+  note: '📋',
+  unknown: '❓'
+});
+
+export const TRACE_COLORS = /** @type {const} */ ({
+  user: 'blue',
+  agent: 'yellow',
+  summary: 'green',
+  command: 'white',
+  apply_patch: 'cyan',
+  write_file: 'magenta',
+  note: 'white',
+  unknown: 'gray'
+});
+
+export const UI_DIMENSIONS = /** @type {const} */ ({
+  HEADER_HEIGHT: 4,
+  MIN_CONTENT_WIDTH: 40,
+  MARGIN: 10
+});

--- a/src/tui/utils/entry-utils.js
+++ b/src/tui/utils/entry-utils.js
@@ -4,6 +4,7 @@ import {
   formatCommandOutput,
 } from './line-formatter.js';
 import { TextLayout } from './text-layout.js';
+import { TRACE_ICONS, TRACE_COLORS } from '../../constants/ui.js';
 
 export const formatTimestamp = (timestamp) => {
   if (!timestamp) return 'No timestamp';
@@ -42,33 +43,7 @@ export const detectTraceType = (entry) => {
 };
 
 // Icon mapping for all supported trace types
-export const TRACE_ICONS = {
-  command: '💻',
-  apply_patch: '🩹',
-  write_file: '📄',
-  user: '👤',
-  agent: '🤖',
-  summary: '📝',
-  note: '📋',
-  unknown: '❓',
-};
-
-// Color mapping for note types
-export const NOTE_COLORS = {
-  user: 'blue',
-  agent: 'yellow',
-  summary: 'green',
-  note: 'white',
-};
-
-export const TRACE_TYPE_COLORS = {
-  user: 'blue',
-  agent: 'yellow',
-  summary: 'green',
-  command: 'white',
-  apply_patch: 'cyan',
-  write_file: 'magenta',
-};
+// Icon and color mappings moved to constants
 
 export const DEFAULT_FILTERS = {
   user: true,
@@ -117,9 +92,9 @@ export const getTraceColor = (type, exitCode) => {
   if (['command', 'apply_patch', 'write_file'].includes(type)) {
     return exitCode !== undefined && exitCode !== 0
       ? 'red'
-      : TRACE_TYPE_COLORS[type] || 'white';
+      : TRACE_COLORS[type] || 'white';
   }
-  if (TRACE_TYPE_COLORS[type]) return TRACE_TYPE_COLORS[type];
+  if (TRACE_COLORS[type]) return TRACE_COLORS[type];
   return type === 'unknown' ? 'gray' : 'white';
 };
 


### PR DESCRIPTION
## Notes
- Converted trace icon and color maps into a new constants module

## Summary
- introduce `src/constants/ui.js` containing trace type, icon, color and dimension constants
- update entry utilities to import constants instead of defining them locally
- adjusted `getTraceColor` logic to use the new constant map

## Testing
- `npm test`