### PR TITLE
Refactor project selector and add spinners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ dist
 # JetBrains IDE project files
 .idea/
 .aider*
+*.backup

--- a/src/tui/components/LoadingSpinner.js
+++ b/src/tui/components/LoadingSpinner.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Text } from 'ink';
+import Spinner from 'ink-spinner';
+
+export const LoadingSpinner = ({ label, type = 'dots2' }) =>
+  React.createElement(
+    Text,
+    null,
+    React.createElement(Spinner, { type }),
+    label ? ` ${label}` : ''
+  );

--- a/src/tui/hooks/useTraceBuffer.js
+++ b/src/tui/hooks/useTraceBuffer.js
@@ -1,9 +1,12 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
+import { LoadingSpinner } from '../components/LoadingSpinner.js';
 
 export const useTraceBuffer = () => {
   const [buffer, setBuffer] = useState(null);
   const [entries, setEntries] = useState([]);
   const [loading, setLoading] = useState(true);
 
-  return { buffer, setBuffer, entries, setEntries, loading, setLoading };
+  const spinner = loading ? React.createElement(LoadingSpinner, {}) : null;
+
+  return { buffer, setBuffer, entries, setEntries, loading: spinner, setLoading };
 };

--- a/src/tui/views/log-viewer/LogViewer.js
+++ b/src/tui/views/log-viewer/LogViewer.js
@@ -10,6 +10,7 @@ import { useFilters } from '../../hooks/useFilters.js';
 import { useAutoScroll } from '../../hooks/useAutoScroll.js';
 import { useStdoutDimensions } from '../../hooks/useStdoutDimensions.js';
 import { useSelection } from '../../hooks/useSelection.js';
+import { LoadingSpinner } from '../../components/LoadingSpinner.js';
 
 const Entry = ({ item, selected }) =>
   React.createElement(
@@ -41,7 +42,8 @@ export const LogViewer = ({ project, onBack, onExit, config }) => {
     setShowFilterModal,
     filtersRef,
   } = useFilters();
-  const { entries, setEntries, buffer, setBuffer } = useTraceBuffer();
+  const { entries, setEntries, buffer, setBuffer, loading, setLoading } =
+    useTraceBuffer();
   const { autoScroll, setAutoScroll, autoScrollRef, updateAutoScrollState } =
     useAutoScroll();
   const {
@@ -262,6 +264,7 @@ export const LogViewer = ({ project, onBack, onExit, config }) => {
   useEffect(() => {
     const buf = new TraceBuffer(project, config?.display?.max_entries || 100);
     setBuffer(buf);
+    setLoading(true);
 
     const update = () => {
       const raw = buf.getTraces();
@@ -273,6 +276,7 @@ export const LogViewer = ({ project, onBack, onExit, config }) => {
       });
 
       setEntries(prepared);
+      setLoading(false);
 
       // Handle details view restoration
       let newDetailsIndex = null;
@@ -408,6 +412,19 @@ export const LogViewer = ({ project, onBack, onExit, config }) => {
     ? ` (${visibleStart + 1}-${visibleEnd} of ${filteredEntries.length}${filterIndicator})`
     : filterIndicator;
   const autoIndicator = ` [a] Auto:${autoScroll ? 'ON' : 'OFF'}`;
+
+  if (loading) {
+    return React.createElement(
+      Box,
+      {
+        flexDirection: 'column',
+        height: terminalHeight,
+        justifyContent: 'center',
+        alignItems: 'center',
+      },
+      React.createElement(LoadingSpinner, { type: 'arc' })
+    );
+  }
 
   // Show filter modal if requested
   if (showFilterModal) {

--- a/src/tui/views/project-selector/ProjectSelector.js
+++ b/src/tui/views/project-selector/ProjectSelector.js
@@ -1,193 +1,86 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Text, useInput } from 'ink';
-import { useStdoutDimensions } from '../../hooks/useStdoutDimensions.js';
+import SelectInput from 'ink-select-input';
 import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
+import { LoadingSpinner } from '../../components/LoadingSpinner.js';
 
-// Custom hook for managing list selection and scrolling
-const useScrollableList = (items, terminalHeight) => {
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [scrollOffset, setScrollOffset] = useState(0);
-
-  const maxVisible = Math.max(3, terminalHeight - 5);
-
-  const navigate = (direction) => {
-    if (direction === 'down' && selectedIndex < items.length - 1) {
-      const newIndex = selectedIndex + 1;
-      setSelectedIndex(newIndex);
-      if (newIndex >= scrollOffset + maxVisible) {
-        setScrollOffset(newIndex - maxVisible + 1);
-      }
-    } else if (direction === 'up' && selectedIndex > 0) {
-      const newIndex = selectedIndex - 1;
-      setSelectedIndex(newIndex);
-      if (newIndex < scrollOffset) {
-        setScrollOffset(newIndex);
-      }
-    }
-  };
-
-  // Reset when items change
-  useEffect(() => {
-    setSelectedIndex(0);
-    setScrollOffset(0);
-  }, [items.length]);
-
-  const visibleItems = items.slice(scrollOffset, scrollOffset + maxVisible);
-  const hasMore = items.length > maxVisible;
-  const scrollIndicator = hasMore
-    ? ` (${scrollOffset + 1}-${Math.min(scrollOffset + maxVisible, items.length)} of ${items.length})`
-    : '';
-
-  return {
-    selectedIndex,
-    visibleItems,
-    scrollIndicator,
-    navigate,
-    getActualIndex: (visibleIndex) => scrollOffset + visibleIndex,
-  };
-};
-
-// Simple project item component
-const ProjectItem = ({ project, selected }) =>
-  React.createElement(
-    Box,
-    {
-      flexDirection: 'row',
-      paddingLeft: 1,
-      paddingRight: 1,
-      borderStyle: selected ? 'single' : undefined,
-      borderColor: selected ? 'cyan' : undefined,
-    },
-    React.createElement(
-      Text,
-      { color: selected ? 'cyan' : undefined, bold: selected },
-      project.name +
-        (project.last
-          ? ` - ${new Date(project.last).toLocaleString()}`
-          : ' - no traces yet')
-    )
-  );
-
-// Empty state component
 const EmptyState = () =>
   React.createElement(
     Box,
     { flexDirection: 'column', paddingX: 1 },
-    React.createElement(
-      Text,
-      { bold: true },
-      'DockaShell TUI - No Projects Found'
-    ),
-    React.createElement(
-      Text,
-      null,
-      '🚫 No traces found in ~/.dockashell/projects'
-    ),
-    React.createElement(
-      Text,
-      null,
-      'Use DockaShell to create a project first.'
-    ),
+    React.createElement(Text, { bold: true }, 'DockaShell TUI - No Projects Found'),
+    React.createElement(Text, null, '🚫 No traces found in ~/.dockashell/projects'),
+    React.createElement(Text, null, 'Use DockaShell to create a project first.'),
     React.createElement(Text, { dimColor: true }, '[q] Quit')
   );
 
 export const ProjectSelector = ({ onSelect, onExit }) => {
-  const [projects, setProjects] = useState([]);
-  const [, terminalHeight] = useStdoutDimensions();
+  const [projects, setProjects] = useState(null);
 
-  const {
-    selectedIndex,
-    visibleItems,
-    scrollIndicator,
-    navigate,
-    getActualIndex,
-  } = useScrollableList(projects, terminalHeight);
+  useInput((input) => {
+    if (input === 'q') {
+      onExit();
+    }
+  });
 
-  // Load projects
   useEffect(() => {
     const loadProjects = async () => {
       const projectsDir = path.join(os.homedir(), '.dockashell', 'projects');
       await fs.ensureDir(projectsDir);
-
       const projectNames = await fs.readdir(projectsDir);
       const list = [];
 
       for (const name of projectNames) {
         const file = path.join(projectsDir, name, 'traces', 'current.jsonl');
         if (!(await fs.pathExists(file))) continue;
-
         try {
           const content = await fs.readFile(file, 'utf8');
           const lines = content.split('\n').filter(Boolean);
           let last = '';
-
           if (lines.length > 0) {
             try {
               const obj = JSON.parse(lines[lines.length - 1]);
               last = obj.timestamp;
-            } catch {
-              // Skip malformed entries
-            }
+            } catch {}
           }
-
           list.push({ name, count: lines.length, last });
-        } catch {
-          // Skip unreadable files
-        }
+        } catch {}
       }
-
-      list.sort(
-        (a, b) => new Date(b.last).getTime() - new Date(a.last).getTime()
-      );
+      list.sort((a, b) => new Date(b.last).getTime() - new Date(a.last).getTime());
       setProjects(list);
     };
-
     loadProjects();
   }, []);
 
-  // Input handling
-  useInput((input, key) => {
-    if (key.downArrow) {
-      navigate('down');
-    } else if (key.upArrow) {
-      navigate('up');
-    } else if (key.return) {
-      const selected = projects[selectedIndex];
-      if (selected) onSelect(selected.name);
-    } else if (input === 'q') {
-      onExit();
-    }
-  });
+  if (projects === null) {
+    return React.createElement(
+      Box,
+      { flexDirection: 'column', paddingX: 1 },
+      React.createElement(Text, { bold: true }, 'DockaShell TUI - Loading Projects'),
+      React.createElement(LoadingSpinner, { type: 'dots' })
+    );
+  }
 
   if (projects.length === 0) {
     return React.createElement(EmptyState);
   }
 
+  const items = projects.map((p) => ({
+    label:
+      p.name + (p.last ? ` - ${new Date(p.last).toLocaleString()}` : ' - no traces yet'),
+    value: p.name,
+  }));
+
   return React.createElement(
     Box,
-    { flexDirection: 'column', height: terminalHeight },
-    React.createElement(
-      Text,
-      { bold: true, marginBottom: 1 },
-      `DockaShell TUI - Select Project${scrollIndicator}`
-    ),
-    React.createElement(
-      Box,
-      { flexDirection: 'column', flexGrow: 1 },
-      ...visibleItems.map((project, i) =>
-        React.createElement(ProjectItem, {
-          key: project.name,
-          project,
-          selected: getActualIndex(i) === selectedIndex,
-        })
-      )
-    ),
-    React.createElement(
-      Text,
-      { dimColor: true, marginTop: 1 },
-      '[↑↓] Navigate  [Enter] Select  [q] Quit'
-    )
+    { flexDirection: 'column' },
+    React.createElement(Text, { bold: true, marginBottom: 1 }, 'DockaShell TUI - Select Project'),
+    React.createElement(SelectInput, {
+      items,
+      onSelect: (item) => onSelect(item.value),
+    }),
+    React.createElement(Text, { dimColor: true, marginTop: 1 }, '[q] Quit')
   );
 };

--- a/test/tui/components/LoadingSpinner.test.js
+++ b/test/tui/components/LoadingSpinner.test.js
@@ -1,0 +1,23 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { LoadingSpinner } from '../../../src/tui/components/LoadingSpinner.js';
+
+describe('LoadingSpinner', () => {
+  test('renders label with spinner', () => {
+    const { lastFrame } = render(
+      React.createElement(LoadingSpinner, { label: 'Loading', type: 'dots' })
+    );
+    assert.ok(lastFrame().includes('Loading'));
+  });
+});
+
+describe('loading states with spinners', () => {
+  test('supports custom spinner type', () => {
+    const { lastFrame } = render(
+      React.createElement(LoadingSpinner, { label: 'Work', type: 'arc' })
+    );
+    assert.ok(lastFrame().includes('Work'));
+  });
+});

--- a/test/tui/views/project-selector/ProjectSelector.test.js
+++ b/test/tui/views/project-selector/ProjectSelector.test.js
@@ -1,0 +1,35 @@
+import { describe, test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { render } from 'ink-testing-library';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import { ProjectSelector } from '../../../../src/tui/views/project-selector/ProjectSelector.js';
+
+describe('ProjectSelector ink-select-input integration', () => {
+  let tmpHome;
+  let oldHome;
+
+  beforeEach(async () => {
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'ds-home-'));
+    oldHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    const traceDir = path.join(tmpHome, '.dockashell', 'projects', 'proj', 'traces');
+    await fs.ensureDir(traceDir);
+    await fs.writeFile(path.join(traceDir, 'current.jsonl'), '{}\n');
+  });
+
+  afterEach(async () => {
+    process.env.HOME = oldHome;
+    if (tmpHome) await fs.remove(tmpHome);
+  });
+
+  test('renders project list', async () => {
+    const { lastFrame } = render(
+      React.createElement(ProjectSelector, { onSelect: () => {}, onExit: () => {} })
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    assert.ok(lastFrame().includes('proj'));
+  });
+});


### PR DESCRIPTION
## Notes
- added new `LoadingSpinner` component
- replaced custom project list logic with `ink-select-input`
- introduced spinners in project and log views
- added tests for spinner and selector integration

## Summary
- use `ink-select-input` in ProjectSelector with a loading spinner
- show arc spinner in LogViewer while traces load
- return spinner element from `useTraceBuffer`
- ignore `*.backup` in git
- test spinner component and ProjectSelector integration