### PR TITLE
Remove maxLines argument

### DIFF
--- a/src/tui/ui-utils/entry-utils.js
+++ b/src/tui/ui-utils/entry-utils.js
@@ -100,7 +100,6 @@ export const buildEntryLines = (
 
 export const prepareEntry = (
   entry,
-  maxLines,
   terminalWidth = LAYOUT.DEFAULT_TERMINAL_WIDTH
 ) => {
   // List view: always 2 lines, compact mode

--- a/src/tui/views/log-viewer/LogViewer.js
+++ b/src/tui/views/log-viewer/LogViewer.js
@@ -120,7 +120,7 @@ export const LogViewer = ({ project, onBack, onExit, config }) => {
 
     const update = () => {
       const raw = buf.getTraces();
-      const prepared = raw.map((e) => prepareEntry(e, null, terminalWidth));
+      const prepared = raw.map((e) => prepareEntry(e, terminalWidth));
 
       const filtered = prepared.filter((entry) => {
         const traceType = entry.traceType || 'unknown';

--- a/test/tui/entry-utils.test.js
+++ b/test/tui/entry-utils.test.js
@@ -45,7 +45,7 @@ describe('formatTimestamp', () => {
 
 describe('prepareEntry', () => {
   test('creates list and detail views', () => {
-    const prepared = prepareEntry(sampleCommand, 10, 80);
+    const prepared = prepareEntry(sampleCommand, 80);
     assert.strictEqual(prepared.lines.length, 2);
     // Full lines are now generated on-demand in TraceDetailsView, not pre-computed
     assert(prepared.entry);


### PR DESCRIPTION
## Summary
- drop the unused `maxLines` param from `prepareEntry`
- update `LogViewer` and tests to call `prepareEntry` with only width

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`
