### PR TITLE
Remove unused trace buffer helpers

### DIFF
--- a/src/tui/ui-utils/trace-buffer.js
+++ b/src/tui/ui-utils/trace-buffer.js
@@ -43,13 +43,6 @@ export class TraceBuffer extends EventEmitter {
     return limit ? this.entries.slice(-limit) : this.entries.slice();
   }
 
-  search(query) {
-    const q = query.toLowerCase();
-    return this.entries.filter((e) =>
-      JSON.stringify(e).toLowerCase().includes(q)
-    );
-  }
-
   onUpdate(callback) {
     this.on('update', callback);
     return () => this.off('update', callback);
@@ -89,14 +82,5 @@ export class TraceBuffer extends EventEmitter {
       await this.watcher.close().catch(() => {});
       this.watcher = null;
     }
-  }
-
-  /**
-   * Manual refresh for historical session data
-   * Use when you need to reload archived sessions (rare operation)
-   */
-  async refreshSessions() {
-    await this.loadFromFiles();
-    this.emit('update');
   }
 }

--- a/test/tui/trace-buffer.test.js
+++ b/test/tui/trace-buffer.test.js
@@ -227,29 +227,4 @@ describe('TraceBuffer', () => {
       assert.strictEqual(traces[1].text, 'Trace3');
     });
   });
-
-  describe('search', () => {
-    beforeEach(async () => {
-      mockListSessions = () => Promise.resolve(['session1']);
-      mockReadTraceEntries = () =>
-        Promise.resolve([
-          { timestamp: '2025-05-26T10:01:00Z', text: 'Hello World' },
-          { timestamp: '2025-05-26T10:02:00Z', text: 'Goodbye Moon' },
-          { timestamp: '2025-05-26T10:03:00Z', text: 'Hello Again' },
-        ]);
-      await buffer.loadFromFiles();
-    });
-
-    test('should find traces containing search term', () => {
-      const results = buffer.search('hello');
-      assert.strictEqual(results.length, 2);
-      assert.strictEqual(results[0].text, 'Hello World');
-      assert.strictEqual(results[1].text, 'Hello Again');
-    });
-
-    test('should return empty array for non-matching search', () => {
-      const results = buffer.search('nonexistent');
-      assert.strictEqual(results.length, 0);
-    });
-  });
 });


### PR DESCRIPTION
## Summary
- delete unused `search` and `refreshSessions` methods from `TraceBuffer`
- drop tests for removed functionality

## Testing
- `npm run format`
- `npm run lint:fix`
- `npm test`
