### PR TITLE
Remove unused selection refs

### DIFF
--- a/src/tui/hooks/useSelection.js
+++ b/src/tui/hooks/useSelection.js
@@ -1,27 +1,8 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 
-export const useSelection = (entries = []) => {
+export const useSelection = () => {
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const selectedIndexRef = useRef(0);
   const [scrollOffset, setScrollOffset] = useState(0);
-  const [detailsViewIndex, setDetailsViewIndex] = useState(null);
-  const detailsViewRef = useRef(null);
-  const selectedTimestampRef = useRef(null);
-  const detailsTimestampRef = useRef(null);
-
-  useEffect(() => {
-    selectedIndexRef.current = selectedIndex;
-    selectedTimestampRef.current =
-      entries[selectedIndex]?.entry.timestamp || null;
-  }, [selectedIndex, entries]);
-
-  useEffect(() => {
-    detailsViewRef.current = detailsViewIndex;
-    if (detailsViewIndex !== null) {
-      detailsTimestampRef.current =
-        entries[detailsViewIndex]?.entry.timestamp || null;
-    }
-  }, [detailsViewIndex, entries]);
 
   const ensureVisible = useCallback(
     (index, entries, terminalHeight, getEntryHeight) => {
@@ -49,14 +30,8 @@ export const useSelection = (entries = []) => {
   return {
     selectedIndex,
     setSelectedIndex,
-    selectedIndexRef,
-    selectedTimestampRef,
     scrollOffset,
     setScrollOffset,
-    detailsViewIndex,
-    setDetailsViewIndex,
-    detailsViewRef,
-    detailsTimestampRef,
     ensureVisible,
   };
 };

--- a/src/tui/views/log-viewer/LogViewer.js
+++ b/src/tui/views/log-viewer/LogViewer.js
@@ -48,24 +48,16 @@ export const LogViewer = ({
   const {
     selectedIndex,
     setSelectedIndex,
-    selectedIndexRef,
-    selectedTimestampRef,
     scrollOffset,
     setScrollOffset,
     ensureVisible,
-  } = useSelection(entries);
+  } = useSelection();
 
   // Filter entries based on current filters
   const filteredEntries = entries.filter((entry) => {
     const traceType = entry.traceType || 'unknown';
     return filters[traceType] !== false; // Show if filter is true or undefined
   });
-
-  useEffect(() => {
-    selectedIndexRef.current = selectedIndex;
-    selectedTimestampRef.current =
-      filteredEntries[selectedIndex]?.entry.timestamp || null;
-  }, [selectedIndex, filteredEntries]);
 
   // Ensure selectedIndex is within bounds when filteredEntries changes
   useEffect(() => {


### PR DESCRIPTION
## Notes
- Simplified `useSelection` by dropping unused refs and parameters
- Updated `LogViewer` to use the new hook signature

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`
