### PR TITLE
Improve useVirtualList caching

### DIFF
--- a/src/tui/components/ScrollableList.js
+++ b/src/tui/components/ScrollableList.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Box } from 'ink';
+
+export const ScrollableList = ({ list, renderItem }) =>
+  React.createElement(
+    Box,
+    { flexDirection: 'column', flexGrow: 1 },
+    ...list.visibleItems.map(({ item, index }) =>
+      renderItem(item, index, index === list.selectedIndex)
+    )
+  );
+
+export default ScrollableList;

--- a/src/tui/hooks/useVirtualList.js
+++ b/src/tui/hooks/useVirtualList.js
@@ -1,0 +1,112 @@
+import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
+import { useStdoutDimensions } from './useStdoutDimensions.js';
+
+/**
+ * Hook to manage large lists with virtual scrolling.
+ *
+ * @param {object} options
+ * @param {number} options.totalCount - Total number of items.
+ * @param {(index: number) => any} options.getItem - Retrieve an item by index.
+ * @param {(item: any, selected: boolean) => number} options.getItemHeight -
+ *   Get the height of an item.
+ * @returns {object} Virtual list state and helpers.
+ */
+
+export const useVirtualList = ({ totalCount, getItem, getItemHeight }) => {
+  const [, terminalHeight] = useStdoutDimensions();
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [scrollOffset, setScrollOffset] = useState(0);
+  const cacheRef = useRef(new Map());
+
+  useEffect(() => {
+    cacheRef.current.clear();
+  }, [getItem, totalCount]);
+
+  const getCachedItem = useCallback(
+    (idx) => {
+      if (idx < 0 || idx >= totalCount) return undefined;
+      if (!cacheRef.current.has(idx)) {
+        cacheRef.current.set(idx, getItem(idx));
+      }
+      return cacheRef.current.get(idx);
+    },
+    [getItem, totalCount]
+  );
+
+  const ensureVisible = useCallback(
+    (index) => {
+      if (totalCount === 0) return;
+      const idx = Math.min(Math.max(index, 0), totalCount - 1);
+      let offset = scrollOffset;
+      if (idx < offset) {
+        offset = idx;
+      } else {
+        const availableHeight = terminalHeight - 3;
+        let height = 0;
+        for (let i = idx; i >= offset; i--) {
+          const item = getCachedItem(i);
+          height += getItemHeight(item, i === idx);
+          if (height > availableHeight) {
+            offset = i + 1;
+            break;
+          }
+        }
+      }
+      offset = Math.min(Math.max(offset, 0), Math.max(0, totalCount - 1));
+      setScrollOffset(offset);
+    },
+    [scrollOffset, terminalHeight, totalCount, getCachedItem, getItemHeight]
+  );
+
+  const calculateVisibleRange = useCallback(() => {
+    if (totalCount === 0) return { start: 0, end: 0 };
+    const availableHeight = terminalHeight - 3;
+    let height = 0;
+    let end = scrollOffset;
+    while (
+      end < totalCount &&
+      height + getItemHeight(getCachedItem(end), end === selectedIndex) <=
+        availableHeight
+    ) {
+      height += getItemHeight(getCachedItem(end), end === selectedIndex);
+      end++;
+    }
+    return { start: scrollOffset, end };
+  }, [
+    scrollOffset,
+    totalCount,
+    terminalHeight,
+    selectedIndex,
+    getCachedItem,
+    getItemHeight,
+  ]);
+
+  const { start: visibleStart, end: visibleEnd } = calculateVisibleRange();
+
+  const visibleItems = useMemo(() => {
+    const list = [];
+    for (let i = visibleStart; i < visibleEnd; i++) {
+      list.push({ index: i, item: getCachedItem(i) });
+    }
+    return list;
+  }, [visibleStart, visibleEnd, getCachedItem]);
+
+  const pageSize = useCallback(() => {
+    const { start, end } = calculateVisibleRange();
+    return end - start || 1;
+  }, [calculateVisibleRange]);
+
+  return {
+    visibleItems,
+    visibleStart,
+    visibleEnd,
+    selectedIndex,
+    setSelectedIndex,
+    scrollOffset,
+    setScrollOffset,
+    ensureVisible,
+    pageSize,
+  };
+};
+
+export default useVirtualList;

--- a/test/tui/use-virtual-list.test.js
+++ b/test/tui/use-virtual-list.test.js
@@ -1,0 +1,70 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { useVirtualList } from '../../src/tui/hooks/useVirtualList.js';
+
+describe('useVirtualList hook', () => {
+  test('computes visible range and keeps selection in view', async () => {
+    process.stdout.rows = 10;
+    const items = Array.from({ length: 5 }, () => ({ height: 2 }));
+    let list;
+    const Test = () => {
+      list = useVirtualList({
+        totalCount: items.length,
+        getItem: (i) => items[i],
+        getItemHeight: (it) => it.height,
+      });
+      return null;
+    };
+    render(React.createElement(Test));
+    await new Promise((r) => setTimeout(r, 20));
+    assert.strictEqual(list.visibleStart, 0);
+    assert.strictEqual(list.visibleEnd, 3);
+    list.setSelectedIndex(4);
+    list.ensureVisible(4);
+    await new Promise((r) => setTimeout(r, 20));
+    assert.strictEqual(list.selectedIndex, 4);
+    assert.strictEqual(list.visibleStart, 2);
+    assert.strictEqual(list.visibleEnd, 5);
+  });
+
+  test('handles zero items', async () => {
+    process.stdout.rows = 10;
+    const items = [];
+    let list;
+    const Test = () => {
+      list = useVirtualList({
+        totalCount: items.length,
+        getItem: (i) => items[i],
+        getItemHeight: () => 1,
+      });
+      return null;
+    };
+    render(React.createElement(Test));
+    await new Promise((r) => setTimeout(r, 20));
+    assert.strictEqual(list.visibleStart, 0);
+    assert.strictEqual(list.visibleEnd, 0);
+    assert.deepStrictEqual(list.visibleItems, []);
+  });
+
+  test('clamps out-of-range index in ensureVisible', async () => {
+    process.stdout.rows = 10;
+    const items = Array.from({ length: 3 }, () => ({ height: 1 }));
+    let list;
+    const Test = () => {
+      list = useVirtualList({
+        totalCount: items.length,
+        getItem: (i) => items[i],
+        getItemHeight: () => 1,
+      });
+      return null;
+    };
+    render(React.createElement(Test));
+    await new Promise((r) => setTimeout(r, 20));
+    list.ensureVisible(10);
+    await new Promise((r) => setTimeout(r, 20));
+    assert.strictEqual(list.scrollOffset, 0);
+    assert.strictEqual(list.visibleEnd, 3);
+  });
+});


### PR DESCRIPTION
## Summary
- add JSDoc for `useVirtualList`
- cache results of `getItem` calls and validate indices
- update tests for edge cases

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`
