### PR TITLE
Fix log viewer state persistence

### DIFF
--- a/src/tui/App.js
+++ b/src/tui/App.js
@@ -4,6 +4,7 @@ import { LogViewer } from './views/LogViewer.js';
 import { TraceDetailsView } from './views/TraceDetailsView.js';
 import { TraceTypesFilterView } from './views/TraceTypesFilterView.js';
 import { loadConfig } from '../utils/config.js';
+import { DEFAULT_FILTERS } from './ui-utils/entry-utils.js';
 
 const defaultTuiConfig = {
   display: {
@@ -14,7 +15,10 @@ const defaultTuiConfig = {
 export const App = ({ projectArg }) => {
   const [project, setProject] = useState(projectArg || null);
   const [config, setConfig] = useState({ tui: defaultTuiConfig });
-  const [filterState, setFilterState] = useState(null);
+  const [filters, setFilters] = useState(DEFAULT_FILTERS);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [scrollOffset, setScrollOffset] = useState(0);
+  const [filterOpen, setFilterOpen] = useState(false);
   const [detailsState, setDetailsState] = useState(null);
 
   useEffect(() => {
@@ -32,13 +36,13 @@ export const App = ({ projectArg }) => {
     });
   }
 
-  if (filterState) {
+  if (filterOpen) {
     return React.createElement(TraceTypesFilterView, {
-      currentFilters: filterState.currentFilters,
-      onBack: () => setFilterState(null),
+      currentFilters: filters,
+      onBack: () => setFilterOpen(false),
       onApply: (newFilters) => {
-        filterState.onApply(newFilters);
-        setFilterState(null);
+        setFilters(newFilters);
+        setFilterOpen(false);
       },
     });
   }
@@ -49,8 +53,8 @@ export const App = ({ projectArg }) => {
       currentIndex: detailsState.currentIndex,
       onClose: () => setDetailsState(null),
       onNavigate: (idx) => {
-        detailsState.onNavigate(idx);
         setDetailsState((prev) => ({ ...prev, currentIndex: idx }));
+        setSelectedIndex(idx);
       },
     });
   }
@@ -58,11 +62,15 @@ export const App = ({ projectArg }) => {
   return React.createElement(LogViewer, {
     project,
     config: config.tui || defaultTuiConfig,
+    filters,
+    selectedIndex,
+    setSelectedIndex,
+    scrollOffset,
+    setScrollOffset,
     onBack: () => setProject(null),
     onExit: () => process.exit(0),
-    onOpenDetails: ({ traces, currentIndex, onNavigate }) =>
-      setDetailsState({ traces, currentIndex, onNavigate }),
-    onOpenFilter: ({ currentFilters, onApply }) =>
-      setFilterState({ currentFilters, onApply }),
+    onOpenDetails: ({ traces, currentIndex }) =>
+      setDetailsState({ traces, currentIndex }),
+    onOpenFilter: () => setFilterOpen(true),
   });
 };

--- a/src/tui/views/LogViewer.js
+++ b/src/tui/views/LogViewer.js
@@ -36,9 +36,13 @@ export const LogViewer = ({
   config,
   onOpenDetails,
   onOpenFilter,
+  filters = DEFAULT_FILTERS,
+  selectedIndex: externalIndex,
+  setSelectedIndex: setExternalIndex,
+  scrollOffset: externalOffset,
+  setScrollOffset: setExternalOffset,
 }) => {
   const [terminalWidth] = useStdoutDimensions();
-  const [filters, setFilters] = useState(DEFAULT_FILTERS);
   const filtersRef = useRef(filters);
   useEffect(() => {
     filtersRef.current = filters;
@@ -66,8 +70,29 @@ export const LogViewer = ({
     pageSize,
     visibleStart,
     visibleEnd,
+    scrollOffset,
     setScrollOffset,
   } = list;
+
+  useEffect(() => {
+    if (externalIndex !== undefined) {
+      setSelectedIndex(externalIndex);
+    }
+  }, [externalIndex, setSelectedIndex]);
+
+  useEffect(() => {
+    if (externalOffset !== undefined) {
+      setScrollOffset(externalOffset);
+    }
+  }, [externalOffset, setScrollOffset]);
+
+  useEffect(() => {
+    if (setExternalIndex) setExternalIndex(selectedIndex);
+  }, [selectedIndex, setExternalIndex]);
+
+  useEffect(() => {
+    if (setExternalOffset) setExternalOffset(scrollOffset);
+  }, [scrollOffset, setExternalOffset]);
 
   // Ensure selectedIndex is within bounds when filteredEntries changes
   useEffect(() => {
@@ -116,7 +141,6 @@ export const LogViewer = ({
       onOpenDetails?.({
         traces: filteredEntries,
         currentIndex: selectedIndex,
-        onNavigate: (newIndex) => setSelectedIndex(newIndex),
       });
     } else if (key.downArrow && selectedIndex < filteredEntries.length - 1) {
       const idx = selectedIndex + 1;
@@ -145,10 +169,7 @@ export const LogViewer = ({
       setSelectedIndex(idx);
       ensureVisible(idx);
     } else if (input === 'f') {
-      onOpenFilter?.({
-        currentFilters: filters,
-        onApply: (newFilters) => setFilters(newFilters),
-      });
+      onOpenFilter?.();
     } else if (input === 'r') {
       buffer?.refresh().catch(() => {});
     } else if (input === 'b') {


### PR DESCRIPTION
## Summary
- preserve filters, selection and scroll offset when changing views
- update LogViewer to sync state with parent component
- remove unused props

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`
