### PR TITLE
Add null/undefined handling for unknown decorator

### DIFF
--- a/src/tui/event-decorators/unknown.js
+++ b/src/tui/event-decorators/unknown.js
@@ -8,6 +8,16 @@ export const unknown = {
   kind: 'unknown',
 
   headerLine(entry) {
+    // Handle cases where entry might be undefined or null
+    if (!entry) {
+      return {
+        type: 'text',
+        icon: TRACE_ICONS.unknown,
+        text: 'No timestamp [UNKNOWN]',
+        color: 'gray',
+        bold: true,
+      };
+    }
     const ts = formatTimestamp(entry.timestamp);
     const type = entry.type || entry.kind || 'unknown';
     return {
@@ -20,6 +30,14 @@ export const unknown = {
   },
 
   contentCompact(entry, width) {
+    if (!entry) {
+      return {
+        type: 'text',
+        text: 'No entry data',
+        color: 'gray',
+        dimOnModal: false,
+      };
+    }
     const tl = new TextLayout(width);
     const text = JSON.stringify(entry).split('\n')[0];
     return {
@@ -31,6 +49,16 @@ export const unknown = {
   },
 
   contentFull(entry, width) {
+    if (!entry) {
+      return [
+        {
+          type: 'text',
+          text: 'No entry data',
+          color: 'white',
+          dimOnModal: false,
+        },
+      ];
+    }
     const tl = new TextLayout(width);
     const lines = [];
 

--- a/src/tui/views/TraceDetailsView.js
+++ b/src/tui/views/TraceDetailsView.js
@@ -34,7 +34,7 @@ export const TraceDetailsView = ({
 
   // Generate full lines on-demand using the decorator system
   const fullLines = buildEntryLines(
-    currentTrace.entry,
+    currentTrace.trace,
     false,
     terminalWidth - 2 // Account for border width (1 char on each side)
   );

--- a/test/tui/event-decorators.test.js
+++ b/test/tui/event-decorators.test.js
@@ -109,4 +109,33 @@ describe('event decorators', () => {
     assert.strictEqual(full[0].text, '{');
     assert(full.some((l) => l.text.includes('"other"')));
   });
+
+  test('unknown decorator handles null/undefined entries', () => {
+    const deco = getDecorator('unknown');
+
+    // Test null entry
+    const headerNull = deco.headerLine(null);
+    assert.strictEqual(headerNull.text, 'No timestamp [UNKNOWN]');
+    assert.strictEqual(headerNull.icon, TRACE_ICONS.unknown);
+    assert.strictEqual(headerNull.color, 'gray');
+
+    const compactNull = deco.contentCompact(null, width);
+    assert.strictEqual(compactNull.text, 'No entry data');
+    assert.strictEqual(compactNull.color, 'gray');
+
+    const fullNull = deco.contentFull(null, width);
+    assert.strictEqual(fullNull.length, 1);
+    assert.strictEqual(fullNull[0].text, 'No entry data');
+
+    // Test undefined entry
+    const headerUndef = deco.headerLine(undefined);
+    assert.strictEqual(headerUndef.text, 'No timestamp [UNKNOWN]');
+
+    const compactUndef = deco.contentCompact(undefined, width);
+    assert.strictEqual(compactUndef.text, 'No entry data');
+
+    const fullUndef = deco.contentFull(undefined, width);
+    assert.strictEqual(fullUndef.length, 1);
+    assert.strictEqual(fullUndef[0].text, 'No entry data');
+  });
 });


### PR DESCRIPTION
The `unknown` event decorator now gracefully handles `null` or `undefined` entry objects in its `headerLine`, `contentCompact`, and `contentFull` methods. This prevents errors and displays informative fallback messages.

Also, corrected the property used to retrieve the current trace entry in `TraceDetailsView` from `currentTrace.entry` to `currentTrace.trace` to ensure the correct data is processed for display.

A new test case verifies the robustness of the `unknown` decorator.