### PR TITLE
Add mouse input handling to TUI

### DIFF
--- a/src/tui/hooks/use-mouse-input.js
+++ b/src/tui/hooks/use-mouse-input.js
@@ -1,0 +1,35 @@
+export const parseMouse = (data) => {
+  // eslint-disable-next-line no-control-regex
+  const match = /\x1b\[<(?<code>\d+);(?<x>\d+);(?<y>\d+)(?<type>[mM])/u.exec(
+    data.toString()
+  );
+  if (!match) return null;
+  const code = Number(match.groups.code);
+  const x = Number(match.groups.x);
+  const y = Number(match.groups.y);
+  const isRelease = match.groups.type === 'm';
+  let wheel;
+  let button;
+  if (code === 64) wheel = 'up';
+  else if (code === 65) wheel = 'down';
+  else if ((code & 3) === 0) button = 'left';
+  else if ((code & 3) === 1) button = 'middle';
+  else if ((code & 3) === 2) button = 'right';
+  return { code, x, y, isRelease, wheel, button };
+};
+
+import { useEffect } from 'react';
+import { useStdin } from 'ink';
+
+export const useMouseInput = (handler) => {
+  const { stdin } = useStdin();
+  useEffect(() => {
+    if (!stdin || !handler) return undefined;
+    const onData = (d) => {
+      const evt = parseMouse(d);
+      if (evt) handler(evt);
+    };
+    stdin.on('data', onData);
+    return () => stdin.off('data', onData);
+  }, [stdin, handler]);
+};

--- a/src/tui/views/LogViewer.js
+++ b/src/tui/views/LogViewer.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { Text, useInput } from 'ink';
+import { useMouseInput } from '../hooks/use-mouse-input.js';
 import { TraceBuffer } from '../ui-utils/trace-buffer.js';
 import { detectTraceType, DEFAULT_FILTERS } from '../ui-utils/entry-utils.js';
 import { AppContainer } from '../components/AppContainer.js';
@@ -164,6 +165,35 @@ export const LogViewer = ({
       onBack();
     } else if (input === 'q') {
       onExit();
+    }
+  });
+
+  // Mouse handling
+  useMouseInput((evt) => {
+    if (evt.wheel === 'up') {
+      if (selectedIndex > 0) {
+        const idx = selectedIndex - 1;
+        setSelectedIndex(idx);
+        ensureVisible(idx);
+      }
+    } else if (evt.wheel === 'down') {
+      if (selectedIndex < filteredEntries.length - 1) {
+        const idx = selectedIndex + 1;
+        setSelectedIndex(idx);
+        ensureVisible(idx);
+      }
+    } else if (evt.button === 'left' && !evt.isRelease) {
+      const startRow = 2; // header + marginTop
+      let r = evt.y - startRow;
+      for (const { item, index } of list.visibleItems) {
+        const h = getEntryHeight(item, index === selectedIndex, terminalWidth);
+        if (r < h) {
+          setSelectedIndex(index);
+          ensureVisible(index);
+          break;
+        }
+        r -= h;
+      }
     }
   });
 

--- a/src/tui/views/TraceDetailsView.js
+++ b/src/tui/views/TraceDetailsView.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Box, Text, useInput } from 'ink';
+import { useMouseInput } from '../hooks/use-mouse-input.js';
 import { AppContainer } from '../components/AppContainer.js';
 import { useStdoutDimensions } from '../hooks/useStdoutDimensions.js';
 import { buildEntryLines } from '../components/TraceItemPreview.js';
@@ -86,6 +87,14 @@ export const TraceDetailsView = ({
     // Close view
     else if (isExitKey(input, key)) {
       onClose();
+    }
+  });
+
+  useMouseInput((evt) => {
+    if (evt.wheel === 'up') {
+      setScrollOffset((prev) => Math.max(0, prev - 1));
+    } else if (evt.wheel === 'down') {
+      setScrollOffset((prev) => Math.min(maxScrollOffset, prev + 1));
     }
   });
 

--- a/test/tui/log-viewer-mouse.test.js
+++ b/test/tui/log-viewer-mouse.test.js
@@ -1,0 +1,83 @@
+import { describe, test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { render } from 'ink-testing-library';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import { LogViewer } from '../../src/tui/views/LogViewer.js';
+
+describe('LogViewer mouse interactions', () => {
+  let tmpHome;
+  let oldHome;
+
+  beforeEach(async () => {
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'ds-home-'));
+    oldHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    const traceDir = path.join(
+      tmpHome,
+      '.dockashell',
+      'projects',
+      'proj',
+      'traces'
+    );
+    await fs.ensureDir(traceDir);
+    await fs.writeFile(
+      path.join(traceDir, 'current.jsonl'),
+      JSON.stringify({ timestamp: '2025-01-01T00:00:00Z', text: 't1' }) +
+        '\n' +
+        JSON.stringify({ timestamp: '2025-01-01T00:00:01Z', text: 't2' }) +
+        '\n'
+    );
+  });
+
+  afterEach(async () => {
+    process.env.HOME = oldHome;
+    if (tmpHome) await fs.remove(tmpHome);
+  });
+
+  test('mouse wheel moves selection', async () => {
+    let detailIndex = null;
+    const { stdin, unmount } = render(
+      React.createElement(LogViewer, {
+        project: 'proj',
+        config: {},
+        onBack: () => {},
+        onExit: () => {},
+        onOpenDetails: ({ currentIndex }) => {
+          detailIndex = currentIndex;
+        },
+      })
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    stdin.write('\x1b[<65;1;3M');
+    await new Promise((r) => setTimeout(r, 20));
+    stdin.write('\r');
+    await new Promise((r) => setTimeout(r, 20));
+    assert.strictEqual(detailIndex, 1);
+    unmount();
+  });
+
+  test('mouse click selects item', async () => {
+    let detailIndex = null;
+    const { stdin, unmount } = render(
+      React.createElement(LogViewer, {
+        project: 'proj',
+        config: {},
+        onBack: () => {},
+        onExit: () => {},
+        onOpenDetails: ({ currentIndex }) => {
+          detailIndex = currentIndex;
+        },
+      })
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    stdin.write('\x1b[<0;5;8M');
+    await new Promise((r) => setTimeout(r, 20));
+    stdin.write('\r');
+    await new Promise((r) => setTimeout(r, 20));
+    assert.strictEqual(detailIndex, 1);
+    unmount();
+  });
+});

--- a/test/tui/mouse-input.test.js
+++ b/test/tui/mouse-input.test.js
@@ -1,0 +1,27 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import { parseMouse } from '../../src/tui/hooks/use-mouse-input.js';
+
+describe('parseMouse', () => {
+  test('parses wheel events', () => {
+    const up = parseMouse('\x1b[<64;1;2M');
+    assert.deepStrictEqual(up, {
+      code: 64,
+      x: 1,
+      y: 2,
+      isRelease: false,
+      wheel: 'up',
+      button: undefined,
+    });
+    const down = parseMouse('\x1b[<65;1;2M');
+    assert.strictEqual(down.wheel, 'down');
+  });
+
+  test('parses button press', () => {
+    const ev = parseMouse('\x1b[<0;10;5M');
+    assert.strictEqual(ev.button, 'left');
+    assert.strictEqual(ev.isRelease, false);
+    assert.strictEqual(ev.x, 10);
+    assert.strictEqual(ev.y, 5);
+  });
+});

--- a/test/tui/trace-details-mouse.test.js
+++ b/test/tui/trace-details-mouse.test.js
@@ -1,0 +1,29 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { TraceDetailsView } from '../../src/tui/views/TraceDetailsView.js';
+
+describe('TraceDetailsView mouse wheel', () => {
+  test('scrolls content with wheel', async () => {
+    process.stdout.rows = 10;
+    const longText = 'x'.repeat(200);
+    const traces = [
+      { trace: { timestamp: '2025-01-01T00:00:00Z', text: longText } },
+    ];
+    const { stdin, lastFrame } = render(
+      React.createElement(TraceDetailsView, {
+        traces,
+        currentIndex: 0,
+        onClose: () => {},
+        onNavigate: () => {},
+      })
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    const first = lastFrame();
+    stdin.write('\x1b[<65;1;3M');
+    await new Promise((r) => setTimeout(r, 20));
+    const scrolled = lastFrame();
+    assert.notStrictEqual(scrolled, first);
+  });
+});


### PR DESCRIPTION
## Summary
- implement a `useMouseInput` hook to parse SGR mouse sequences
- enable mouse wheel scrolling and click selection in `LogViewer`
- enable mouse wheel scrolling in `TraceDetailsView`
- test mouse parsing and component interactions

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`
