### PR TITLE
Fix log viewer selection flicker

### DIFF
--- a/src/tui/hooks/useVirtualList.js
+++ b/src/tui/hooks/useVirtualList.js
@@ -12,10 +12,16 @@ import { useStdoutDimensions } from './useStdoutDimensions.js';
  * @returns {object} Virtual list state and helpers.
  */
 
-export const useVirtualList = ({ totalCount, getItem, getItemHeight }) => {
+export const useVirtualList = ({
+  totalCount,
+  getItem,
+  getItemHeight,
+  initialIndex = 0,
+  initialOffset = 0,
+}) => {
   const [, terminalHeight] = useStdoutDimensions();
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [scrollOffset, setScrollOffset] = useState(0);
+  const [selectedIndex, setSelectedIndex] = useState(initialIndex);
+  const [scrollOffset, setScrollOffset] = useState(initialOffset);
   const cacheRef = useRef(new Map());
 
   useEffect(() => {

--- a/src/tui/views/LogViewer.js
+++ b/src/tui/views/LogViewer.js
@@ -53,6 +53,8 @@ export const LogViewer = ({
     getItem: (idx) => filteredEntries[idx],
     getItemHeight: (item, selected) =>
       getEntryHeight(item, selected, terminalWidth),
+    initialIndex: externalIndex,
+    initialOffset: externalOffset,
   });
 
   const {
@@ -67,12 +69,6 @@ export const LogViewer = ({
   } = list;
 
   useEffect(() => {
-    if (externalIndex !== undefined) {
-      setSelectedIndex(externalIndex);
-    }
-  }, [externalIndex, setSelectedIndex]);
-
-  useEffect(() => {
     if (selectedTimestamp) {
       const idx = findClosestIndexByTimestamp(
         filteredEntries,
@@ -82,12 +78,6 @@ export const LogViewer = ({
       ensureVisible(idx);
     }
   }, [selectedTimestamp, filteredEntries, setSelectedIndex, ensureVisible]);
-
-  useEffect(() => {
-    if (externalOffset !== undefined) {
-      setScrollOffset(externalOffset);
-    }
-  }, [externalOffset, setScrollOffset]);
 
   useEffect(() => {
     if (setExternalIndex) setExternalIndex(selectedIndex);

--- a/test/tui/use-virtual-list.test.js
+++ b/test/tui/use-virtual-list.test.js
@@ -67,4 +67,24 @@ describe('useVirtualList hook', () => {
     assert.strictEqual(list.scrollOffset, 0);
     assert.strictEqual(list.visibleEnd, 3);
   });
+
+  test('respects initial index and offset', async () => {
+    process.stdout.rows = 10;
+    const items = Array.from({ length: 10 }, () => ({ height: 1 }));
+    let list;
+    const Test = () => {
+      list = useVirtualList({
+        totalCount: items.length,
+        getItem: (i) => items[i],
+        getItemHeight: () => 1,
+        initialIndex: 5,
+        initialOffset: 3,
+      });
+      return null;
+    };
+    render(React.createElement(Test));
+    await new Promise((r) => setTimeout(r, 20));
+    assert.strictEqual(list.selectedIndex, 5);
+    assert.strictEqual(list.scrollOffset, 3);
+  });
 });


### PR DESCRIPTION
## Summary
- propagate initial selection/offset to useVirtualList
- update LogViewer to avoid state reset and flicker
- test useVirtualList initial state

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`
