### PR TITLE
Include archived sessions when listing projects

### DIFF
--- a/src/tui/ui-utils/project-discovery.js
+++ b/src/tui/ui-utils/project-discovery.js
@@ -1,0 +1,75 @@
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import {
+  getCurrentTraceFile,
+  getSessionsDir,
+} from '../../utils/trace-paths.js';
+
+export async function discoverProjects() {
+  const projectsDir = path.join(os.homedir(), '.dockashell', 'projects');
+  await fs.ensureDir(projectsDir);
+  const projectNames = await fs.readdir(projectsDir);
+  const list = [];
+
+  for (const name of projectNames) {
+    const currentFile = getCurrentTraceFile(name);
+    const sessionsDir = getSessionsDir(name);
+    let last = '';
+    let count = 0;
+
+    if (await fs.pathExists(currentFile)) {
+      try {
+        const content = await fs.readFile(currentFile, 'utf8');
+        const lines = content.split('\n').filter(Boolean);
+        count += lines.length;
+        if (lines.length > 0) {
+          try {
+            const obj = JSON.parse(lines[lines.length - 1]);
+            last = obj.timestamp || last;
+          } catch {
+            // ignore parse errors
+          }
+        }
+      } catch {
+        // ignore read errors
+      }
+    }
+
+    if (await fs.pathExists(sessionsDir)) {
+      const files = (await fs.readdir(sessionsDir)).filter((f) =>
+        f.endsWith('.jsonl')
+      );
+      for (const f of files) {
+        try {
+          const content = await fs.readFile(path.join(sessionsDir, f), 'utf8');
+          const lines = content.split('\n').filter(Boolean);
+          count += lines.length;
+          if (lines.length > 0) {
+            try {
+              const obj = JSON.parse(lines[lines.length - 1]);
+              const ts = obj.timestamp;
+              if (
+                ts &&
+                (!last || new Date(ts).getTime() > new Date(last).getTime())
+              ) {
+                last = ts;
+              }
+            } catch {
+              // ignore parse errors
+            }
+          }
+        } catch {
+          // ignore read errors
+        }
+      }
+    }
+
+    if (count > 0) {
+      list.push({ name, count, last });
+    }
+  }
+
+  list.sort((a, b) => new Date(b.last).getTime() - new Date(a.last).getTime());
+  return list;
+}

--- a/test/tui/views/project-selector/ProjectSelector.test.js
+++ b/test/tui/views/project-selector/ProjectSelector.test.js
@@ -23,7 +23,6 @@ describe('ProjectSelector ink-ui integration', () => {
       'traces'
     );
     await fs.ensureDir(traceDir);
-    await fs.writeFile(path.join(traceDir, 'current.jsonl'), '{}\n');
   });
 
   afterEach(async () => {
@@ -32,6 +31,14 @@ describe('ProjectSelector ink-ui integration', () => {
   });
 
   test('renders project list', async () => {
+    const traceDir = path.join(
+      tmpHome,
+      '.dockashell',
+      'projects',
+      'proj',
+      'traces'
+    );
+    await fs.writeFile(path.join(traceDir, 'current.jsonl'), '{}\n');
     const { lastFrame } = render(
       React.createElement(ProjectSelector, {
         onSelect: () => {},
@@ -43,5 +50,28 @@ describe('ProjectSelector ink-ui integration', () => {
     assert.ok(frame.includes('proj'));
     assert.ok(frame.includes('[↑↓] Navigate'));
     assert.ok(frame.includes('[Enter] Open'));
+  });
+
+  test('lists project with only archived sessions', async () => {
+    const sessionsDir = path.join(
+      tmpHome,
+      '.dockashell',
+      'projects',
+      'proj',
+      'traces',
+      'sessions'
+    );
+    await fs.ensureDir(sessionsDir);
+    await fs.writeFile(path.join(sessionsDir, 'old.jsonl'), '{}\n');
+
+    const { lastFrame } = render(
+      React.createElement(ProjectSelector, {
+        onSelect: () => {},
+        onExit: () => {},
+      })
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    const frame = lastFrame();
+    assert.ok(frame.includes('proj'));
   });
 });


### PR DESCRIPTION
## Summary
- add `discoverProjects` util for project discovery
- use it in `ProjectSelector`
- test listing projects when traces only exist in archived sessions

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`
