### PR TITLE
Add unit tests for MCP tools

### DIFF
--- a/test/mcp/execution-tools.test.js
+++ b/test/mcp/execution-tools.test.js
@@ -1,0 +1,92 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import { registerExecutionTools } from '../../src/mcp/tools/execution-tools.js';
+
+function createServer() {
+  return {
+    tools: {},
+    tool(name, _schema, handler) {
+      this.tools[name] = { handler };
+    },
+  };
+}
+
+describe('execution-tools', () => {
+  test('registers tools', () => {
+    const server = createServer();
+    registerExecutionTools(server, {}, {}, {});
+    assert.ok(server.tools.run_command);
+    assert.ok(server.tools.apply_patch);
+    assert.ok(server.tools.write_file);
+  });
+
+  test('run_command success', async () => {
+    const server = createServer();
+    const pm = { loadProject: async () => ({}) };
+    const cm = {
+      executeCommand: async () => ({
+        exitCode: 0,
+        success: true,
+        stdout: 'ok',
+        stderr: '',
+        timedOut: false,
+      }),
+    };
+    const sm = { validateCommand: () => {}, getMaxExecutionTime: () => 1 };
+    registerExecutionTools(server, pm, cm, sm);
+    const result = await server.tools.run_command.handler({
+      project_name: 'proj',
+      command: 'ls',
+    });
+    assert.strictEqual(result.isError, undefined);
+    assert.ok(result.content[0].text.includes('**Exit Code:** 0'));
+  });
+
+  test('run_command failure response', async () => {
+    const server = createServer();
+    const pm = { loadProject: async () => ({}) };
+    const cm = {
+      executeCommand: async () => ({ success: false, exitCode: 1 }),
+    };
+    const sm = { validateCommand: () => {}, getMaxExecutionTime: () => 1 };
+    registerExecutionTools(server, pm, cm, sm);
+    const res = await server.tools.run_command.handler({
+      project_name: 'p',
+      command: 'ls',
+    });
+    assert.strictEqual(res.isError, true);
+  });
+
+  test('run_command invalid command throws', async () => {
+    const server = createServer();
+    registerExecutionTools(server, {}, {}, {});
+    await assert.rejects(
+      server.tools.run_command.handler({ project_name: 'p', command: '' }),
+      /Command must be a non-empty string/
+    );
+  });
+
+  test('apply_patch success', async () => {
+    const server = createServer();
+    const pm = { loadProject: async () => ({}) };
+    const cm = {
+      applyPatch: async () => ({ exitCode: 0, success: true }),
+    };
+    registerExecutionTools(server, pm, cm, {});
+    const res = await server.tools.apply_patch.handler({
+      project_name: 'p',
+      patch: 'diff',
+    });
+    assert.strictEqual(res.isError, undefined);
+    assert.ok(res.content[0].text.includes('**Exit Code:** 0'));
+  });
+
+  test('write_file invalid path throws', async () => {
+    const server = createServer();
+    registerExecutionTools(server, {}, {}, {});
+    await assert.rejects(
+      server.tools.write_file.handler({ project_name: 'p', path: null }),
+      /Path must be a non-empty string/
+    );
+  });
+});

--- a/test/mcp/helpers.test.js
+++ b/test/mcp/helpers.test.js
@@ -1,0 +1,28 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import {
+  validateProjectName,
+  textResponse,
+} from '../../src/mcp/tools/helpers.js';
+
+describe('helpers', () => {
+  test('validateProjectName accepts valid name', () => {
+    assert.doesNotThrow(() => validateProjectName('proj'));
+  });
+
+  test('validateProjectName rejects invalid name', () => {
+    assert.throws(
+      () => validateProjectName(''),
+      /Project name must be a non-empty string/
+    );
+    assert.throws(
+      () => validateProjectName(null),
+      /Project name must be a non-empty string/
+    );
+  });
+
+  test('textResponse returns expected structure', () => {
+    const res = textResponse('hi');
+    assert.deepStrictEqual(res, { content: [{ type: 'text', text: 'hi' }] });
+  });
+});

--- a/test/mcp/log-tools.test.js
+++ b/test/mcp/log-tools.test.js
@@ -1,0 +1,84 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import { registerLogTools } from '../../src/mcp/tools/log-tools.js';
+
+function createServer() {
+  return {
+    tools: {},
+    tool(name, _schema, handler) {
+      this.tools[name] = { handler };
+    },
+  };
+}
+
+describe('log-tools', () => {
+  test('registers tools', () => {
+    const server = createServer();
+    registerLogTools(server, {});
+    assert.ok(server.tools.write_trace);
+    assert.ok(server.tools.read_traces);
+  });
+
+  test('write_trace records note', async () => {
+    const server = createServer();
+    const logger = { logNote: async () => {} };
+    registerLogTools(server, logger);
+    const res = await server.tools.write_trace.handler({
+      project_name: 'p',
+      type: 'user',
+      text: 'hi',
+    });
+    assert.deepStrictEqual(res, {
+      content: [{ type: 'text', text: 'Trace recorded' }],
+    });
+  });
+
+  test('write_trace error bubbles', async () => {
+    const server = createServer();
+    const logger = {
+      logNote: async () => {
+        throw new Error('oops');
+      },
+    };
+    registerLogTools(server, logger);
+    await assert.rejects(
+      server.tools.write_trace.handler({
+        project_name: 'p',
+        type: 'user',
+        text: 'x',
+      }),
+      /Failed to write trace: oops/
+    );
+  });
+
+  test('read_traces returns formatted text', async () => {
+    const server = createServer();
+    const logger = {
+      readTraces: async () => [
+        {
+          timestamp: 't',
+          kind: 'command',
+          command: 'ls',
+          result: { exitCode: 0 },
+        },
+      ],
+    };
+    registerLogTools(server, logger);
+    const res = await server.tools.read_traces.handler({ project_name: 'p' });
+    assert.ok(res.content[0].text.includes('[COMMAND]'));
+  });
+
+  test('read_traces error bubbles', async () => {
+    const server = createServer();
+    const logger = {
+      readTraces: async () => {
+        throw new Error('bad');
+      },
+    };
+    registerLogTools(server, logger);
+    await assert.rejects(
+      server.tools.read_traces.handler({ project_name: 'p' }),
+      /Failed to read traces: bad/
+    );
+  });
+});

--- a/test/mcp/project-tools.test.js
+++ b/test/mcp/project-tools.test.js
@@ -1,0 +1,59 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import { registerProjectTools } from '../../src/mcp/tools/project-tools.js';
+
+function createServer() {
+  return {
+    tools: {},
+    tool(name, _schema, handler) {
+      this.tools[name] = { handler };
+    },
+  };
+}
+
+describe('project-tools', () => {
+  test('registers tools', () => {
+    const server = createServer();
+    registerProjectTools(server, {}, {});
+    assert.ok(server.tools.list_projects);
+    assert.ok(server.tools.start_project);
+    assert.ok(server.tools.stop_project);
+    assert.ok(server.tools.project_status);
+  });
+
+  test('list_projects no projects', async () => {
+    const server = createServer();
+    const pm = { listProjects: async () => [] };
+    registerProjectTools(server, pm, {});
+    const res = await server.tools.list_projects.handler();
+    assert.ok(res.content[0].text.includes('No projects configured'));
+  });
+
+  test('start_project success', async () => {
+    const server = createServer();
+    const pm = {
+      loadProject: async () => ({ image: 'img', mounts: [], ports: [] }),
+      listProjects: async () => [],
+    };
+    const cm = {
+      startContainer: async () => ({
+        containerId: 'id',
+        status: 'running',
+        ports: [],
+      }),
+    };
+    registerProjectTools(server, pm, cm);
+    const res = await server.tools.start_project.handler({ project_name: 'p' });
+    assert.ok(res.content[0].text.includes('# Project Started: p'));
+  });
+
+  test('project_status not found', async () => {
+    const server = createServer();
+    const cm = { getStatus: async () => ({ status: 'not_found' }) };
+    registerProjectTools(server, {}, cm);
+    const res = await server.tools.project_status.handler({
+      project_name: 'p',
+    });
+    assert.ok(res.content[0].text.includes('Container not found'));
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for helper utilities
- test execution, log, and project tool registration and behavior

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`
