### PR TITLE
Switch core classes to default exports

### DIFF
--- a/src/core/container-manager.js
+++ b/src/core/container-manager.js
@@ -1,9 +1,9 @@
 import Docker from 'dockerode';
 import os from 'os';
 import { PassThrough } from 'stream';
-import { Logger } from '../utils/logger.js';
+import Logger from '../utils/logger.js';
 
-export class ContainerManager {
+class ContainerManager {
   constructor(projectManager) {
     this.docker = new Docker();
     this.projectManager = projectManager;
@@ -627,3 +627,5 @@ export class ContainerManager {
     // Optionally log that we're disconnecting but leaving containers running
   }
 }
+
+export default ContainerManager;

--- a/src/core/project-manager.js
+++ b/src/core/project-manager.js
@@ -3,7 +3,7 @@ import path from 'path';
 import os from 'os';
 import { defaultConfig } from '../utils/default-config.js';
 
-export class ProjectManager {
+class ProjectManager {
   constructor() {
     this.configDir = path.join(os.homedir(), '.dockashell');
     this.projectsDir = path.join(this.configDir, 'projects');
@@ -211,3 +211,5 @@ export class ProjectManager {
     }
   }
 }
+
+export default ProjectManager;

--- a/src/core/security.js
+++ b/src/core/security.js
@@ -1,4 +1,4 @@
-export class SecurityManager {
+class SecurityManager {
   constructor() {}
 
   validateCommand(command, projectConfig) {
@@ -40,3 +40,5 @@ export class SecurityManager {
     };
   }
 }
+
+export default SecurityManager;

--- a/src/mcp/mcp-server.js
+++ b/src/mcp/mcp-server.js
@@ -5,10 +5,10 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { registerProjectTools } from './tools/project-tools.js';
 import { registerExecutionTools } from './tools/execution-tools.js';
 import { registerLogTools } from './tools/log-tools.js';
-import { ProjectManager } from '../core/project-manager.js';
-import { ContainerManager } from '../core/container-manager.js';
-import { SecurityManager } from '../core/security.js';
-import { Logger } from '../utils/logger.js';
+import ProjectManager from '../core/project-manager.js';
+import ContainerManager from '../core/container-manager.js';
+import SecurityManager from '../core/security.js';
+import Logger from '../utils/logger.js';
 
 class DockashellServer {
   constructor() {
@@ -78,7 +78,7 @@ class DockashellServer {
 }
 
 // Export the class for testing
-export { DockashellServer };
+export default DockashellServer;
 
 // Run the server
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
 import { systemLogger } from './system-logger.js';
-import { TraceRecorder } from './trace-recorder.js';
+import TraceRecorder from './trace-recorder.js';
 import { loadConfig } from './config.js';
 import { parseTraceLines } from './trace-utils.js';
 
@@ -26,7 +26,7 @@ const parseDuration = (value) => {
   }
 };
 
-export class Logger {
+class Logger {
   constructor() {
     this.traceRecorders = new Map();
     this._config = null;
@@ -183,3 +183,5 @@ export class Logger {
     this.traceRecorders.clear();
   }
 }
+
+export default Logger;

--- a/src/utils/system-logger.js
+++ b/src/utils/system-logger.js
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
 
-export class SystemLogger {
+class SystemLogger {
   constructor() {
     this.logsDir = path.join(os.homedir(), '.dockashell', 'logs');
     this.logFile = path.join(this.logsDir, 'system.log');
@@ -36,3 +36,5 @@ export class SystemLogger {
 }
 
 export const systemLogger = new SystemLogger();
+
+export default SystemLogger;

--- a/src/utils/trace-recorder.js
+++ b/src/utils/trace-recorder.js
@@ -6,7 +6,7 @@ import {
   getSessionsDir,
 } from './trace-paths.js';
 
-export class TraceRecorder {
+class TraceRecorder {
   constructor(projectName, sessionTimeoutMs = 4 * 60 * 60 * 1000) {
     this.projectName = projectName;
     this.baseDir = getProjectTraceDir(projectName);
@@ -114,3 +114,5 @@ export class TraceRecorder {
     }
   }
 }
+
+export default TraceRecorder;

--- a/test/core/project-manager.test.js
+++ b/test/core/project-manager.test.js
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
-import { ProjectManager } from '../../src/core/project-manager.js';
+import ProjectManager from '../../src/core/project-manager.js';
 import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';

--- a/test/core/security.test.js
+++ b/test/core/security.test.js
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach } from 'node:test';
 import assert from 'node:assert';
-import { SecurityManager } from '../../src/core/security.js';
+import SecurityManager from '../../src/core/security.js';
 
 describe('SecurityManager', () => {
   let securityManager;

--- a/test/integration/test-error-handling.js
+++ b/test/integration/test-error-handling.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { DockashellServer } from '../../src/mcp/mcp-server.js';
+import DockashellServer from '../../src/mcp/mcp-server.js';
 
 // Test error handling for each tool
 async function testErrorHandling() {

--- a/test/integration/test-server.js
+++ b/test/integration/test-server.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { DockashellServer } from '../../src/mcp/mcp-server.js';
+import DockashellServer from '../../src/mcp/mcp-server.js';
 
 // Simple test to verify the server can initialize
 async function testServer() {

--- a/test/integration/test-timeout.js
+++ b/test/integration/test-timeout.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { ContainerManager } from '../../src/core/container-manager.js';
-import { ProjectManager } from '../../src/core/project-manager.js';
+import ContainerManager from '../../src/core/container-manager.js';
+import ProjectManager from '../../src/core/project-manager.js';
 
 async function testTimeout() {
   console.log('Testing timeout functionality...');

--- a/test/utils/logger.test.js
+++ b/test/utils/logger.test.js
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
-import { Logger } from '../../src/utils/logger.js';
+import Logger from '../../src/utils/logger.js';
 import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';

--- a/test/utils/system-logger.test.js
+++ b/test/utils/system-logger.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
-import { SystemLogger } from '../../src/utils/system-logger.js';
+import SystemLogger from '../../src/utils/system-logger.js';
 
 describe('SystemLogger', () => {
   let tmpDir;

--- a/test/utils/trace-recorder.test.js
+++ b/test/utils/trace-recorder.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
-import { TraceRecorder } from '../../src/utils/trace-recorder.js';
+import TraceRecorder from '../../src/utils/trace-recorder.js';
 
 describe('TraceRecorder', () => {
   let tmpHome;


### PR DESCRIPTION
## Summary
- refactor core and utils classes to use default exports
- update import statements accordingly

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`
