### PR TITLE
Ensure decorators use TRACE_COLORS for headers

### DIFF
--- a/src/tui/event-decorators/shell.js
+++ b/src/tui/event-decorators/shell.js
@@ -38,7 +38,7 @@ function createShellDecorator({
         type: 'text',
         icon,
         text: `${ts} [${label} exit:${exit} dur:${duration}] [↑:${inLines} ↓:${outLines} lines]`,
-        color: exit === 0 ? color : 'red',
+        color: exit === 0 ? color : TRACE_COLORS.error,
         bold: true,
       };
     },

--- a/src/tui/event-decorators/unknown.js
+++ b/src/tui/event-decorators/unknown.js
@@ -1,7 +1,7 @@
 import { formatTimestamp } from '../ui-utils/entry-utils.js';
 import { TextLayout } from '../ui-utils/text-utils.js';
 
-import { TRACE_ICONS } from '../ui-utils/constants.js';
+import { TRACE_ICONS, TRACE_COLORS } from '../ui-utils/constants.js';
 
 /** @type {import('./index.js').EventDecorator} */
 export const unknown = {
@@ -14,7 +14,7 @@ export const unknown = {
         type: 'text',
         icon: TRACE_ICONS.unknown,
         text: 'No timestamp [UNKNOWN]',
-        color: 'gray',
+        color: TRACE_COLORS.unknown,
         bold: true,
       };
     }
@@ -24,7 +24,7 @@ export const unknown = {
       type: 'text',
       icon: TRACE_ICONS.unknown,
       text: `${ts} [${type.toUpperCase()}]`,
-      color: 'gray',
+      color: TRACE_COLORS.unknown,
       bold: true,
     };
   },

--- a/src/tui/ui-utils/constants.js
+++ b/src/tui/ui-utils/constants.js
@@ -66,4 +66,5 @@ export const TRACE_COLORS = /** @type {const} */ ({
   write_file: 'magenta',
   note: 'white',
   unknown: 'gray',
+  error: 'red',
 });

--- a/test/tui/event-decorators.test.js
+++ b/test/tui/event-decorators.test.js
@@ -23,7 +23,7 @@ describe('event decorators', () => {
       `${formatted} [COMMAND exit:0 dur:N/A] [↑:1 ↓:1 lines]`
     );
     assert.strictEqual(header.icon, TRACE_ICONS.command);
-    assert.strictEqual(header.color, 'white');
+    assert.strictEqual(header.color, TRACE_COLORS.command);
     assert(header.bold);
 
     const compact = deco.contentCompact(entry, width);
@@ -109,7 +109,7 @@ describe('event decorators', () => {
     const header = deco.headerLine(entry);
     assert.strictEqual(header.text, `${formatted} [UNKNOWN]`);
     assert.strictEqual(header.icon, TRACE_ICONS.unknown);
-    assert.strictEqual(header.color, 'gray');
+    assert.strictEqual(header.color, TRACE_COLORS.unknown);
 
     const compact = deco.contentCompact(entry, width);
     assert.ok(compact.text.startsWith('{'));
@@ -126,7 +126,7 @@ describe('event decorators', () => {
     const headerNull = deco.headerLine(null);
     assert.strictEqual(headerNull.text, 'No timestamp [UNKNOWN]');
     assert.strictEqual(headerNull.icon, TRACE_ICONS.unknown);
-    assert.strictEqual(headerNull.color, 'gray');
+    assert.strictEqual(headerNull.color, TRACE_COLORS.unknown);
 
     const compactNull = deco.contentCompact(null, width);
     assert.strictEqual(compactNull.text, 'No entry data');


### PR DESCRIPTION
## Summary
- add `error` color to TRACE_COLORS
- use TRACE_COLORS in unknown and shell decorators
- update tests for new header colors

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`