### PR TITLE
Return partial output on command timeout

### DIFF
--- a/test/core/container-manager-execute.test.js
+++ b/test/core/container-manager-execute.test.js
@@ -1,0 +1,47 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import { PassThrough } from 'stream';
+import ContainerManager from '../../src/core/container-manager.js';
+
+function createManager(stream) {
+  const manager = new ContainerManager({});
+  manager.logger = { logCommand: async () => {} };
+  manager.docker = {
+    getContainer: () => ({
+      inspect: async () => ({ State: { Running: true }, Config: {}, Id: 'id' }),
+      exec: async ({ Cmd }) => {
+        if (Cmd[0] === 'kill') {
+          return { start: async () => {} };
+        }
+        return {
+          start: async () => stream,
+          inspect: async () => ({ ExitCode: 0, Pid: 123 }),
+        };
+      },
+      modem: {
+        demuxStream: (s, stdout, _stderr) => {
+          s.on('data', (d) => stdout.write(d));
+        },
+      },
+    }),
+  };
+  return manager;
+}
+
+describe('ContainerManager.executeCommand', () => {
+  test('returns partial output on timeout', async () => {
+    const stream = new PassThrough();
+    const manager = createManager(stream);
+
+    const promise = manager.executeCommand('proj', 'cmd', { timeout: 10 });
+    setImmediate(() => {
+      stream.emit('data', Buffer.from('partial'));
+    });
+    const result = await promise;
+
+    assert.strictEqual(result.timedOut, true);
+    assert.strictEqual(result.exitCode, -1);
+    assert.strictEqual(result.stdout, 'partial');
+    assert.strictEqual(result.stderr, 'Command timed out');
+  });
+});


### PR DESCRIPTION
## Summary
- propagate partial stdout/stderr when `executeCommand` times out
- cover timeout case in `ContainerManager` tests
- avoid variable shadowing when catching errors

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_683b4ec63d808324aa75e83f40698c05