### PR TITLE
Add nanostore-based state management

### DIFF
--- a/src/tui/stores/config-store.js
+++ b/src/tui/stores/config-store.js
@@ -1,0 +1,13 @@
+import { atom } from 'nanostores';
+import { defaultConfig } from '../../utils/default-config.js';
+import { loadConfig } from '../../utils/config.js';
+
+export const $appConfig = atom({ ...defaultConfig });
+
+loadConfig()
+  .then((cfg) => $appConfig.set(cfg))
+  .catch(() => {});
+
+export function updateConfig(cfg) {
+  $appConfig.set(cfg);
+}

--- a/src/tui/stores/filter-store.js
+++ b/src/tui/stores/filter-store.js
@@ -1,0 +1,8 @@
+import { atom } from 'nanostores';
+import { DEFAULT_FILTERS } from '../ui-utils/entry-utils.js';
+
+export const $traceFilters = atom({ ...DEFAULT_FILTERS });
+
+export function setTraceFilters(filters) {
+  $traceFilters.set(filters);
+}

--- a/src/tui/stores/project-store.js
+++ b/src/tui/stores/project-store.js
@@ -1,0 +1,7 @@
+import { atom } from 'nanostores';
+
+export const $activeProject = atom(null);
+
+export function setActiveProject(name) {
+  $activeProject.set(name);
+}

--- a/src/tui/views/project-selector.js
+++ b/src/tui/views/project-selector.js
@@ -5,6 +5,7 @@ import { AppContainer } from '../components/app-container.js';
 import { SHORTCUTS, buildFooter } from '../ui-utils/constants.js';
 import { isBackKey } from '../ui-utils/text-utils.js';
 import { discoverProjects } from '../ui-utils/project-discovery.js';
+import { setActiveProject } from '../stores/project-store.js';
 
 export const ProjectSelector = ({ onSelect, onExit }) => {
   const [projects, setProjects] = useState([]);
@@ -50,7 +51,13 @@ export const ProjectSelector = ({ onSelect, onExit }) => {
       Box,
       { flexDirection: 'column', flexGrow: 1, width: '100%' },
       projects.length > 0
-        ? React.createElement(Select, { options, onChange: onSelect })
+        ? React.createElement(Select, {
+            options,
+            onChange: (value) => {
+              setActiveProject(value);
+              onSelect?.(value);
+            },
+          })
         : React.createElement(
             Box,
             { flexDirection: 'column' },

--- a/src/tui/views/trace-types-filter-view.js
+++ b/src/tui/views/trace-types-filter-view.js
@@ -3,14 +3,16 @@ import { useInput, Text } from 'ink';
 import { MultiSelect } from '@inkjs/ui';
 import { useStdoutDimensions } from '../hooks/use-stdout-dimensions.js';
 import { AppContainer } from '../components/app-container.js';
+import { useStore } from '@nanostores/react';
 import { DEFAULT_FILTERS } from '../ui-utils/entry-utils.js';
+import { $traceFilters, setTraceFilters } from '../stores/filter-store.js';
 import { SHORTCUTS, buildFooter } from '../ui-utils/constants.js';
 import { isBackKey } from '../ui-utils/text-utils.js';
 
 /**
  * Full screen trace type filter view using ink-ui MultiSelect.
  */
-export const TraceTypesFilterView = ({ onBack, onApply, currentFilters }) => {
+export const TraceTypesFilterView = ({ onBack }) => {
   const [, terminalHeight] = useStdoutDimensions();
 
   const traceTypes = [
@@ -41,13 +43,15 @@ export const TraceTypesFilterView = ({ onBack, onApply, currentFilters }) => {
     return newFilters;
   };
 
+  const storeFilters = useStore($traceFilters);
   const [selectedValues, setSelectedValues] = useState(
-    filtersToArray(currentFilters || DEFAULT_FILTERS)
+    filtersToArray(storeFilters || DEFAULT_FILTERS)
   );
 
   const handleSubmit = (finalValues) => {
     const newFilters = arrayToFilters(finalValues);
-    onApply(newFilters);
+    setTraceFilters(newFilters);
+    onBack?.();
   };
 
   useInput((input, key) => {

--- a/test/tui/log-viewer-callbacks.test.js
+++ b/test/tui/log-viewer-callbacks.test.js
@@ -7,6 +7,7 @@ import path from 'path';
 import os from 'os';
 import { TraceProvider } from '../../src/tui/contexts/trace-context.js';
 import { LogViewer } from '../../src/tui/views/log-viewer.js';
+import { setActiveProject } from '../../src/tui/stores/project-store.js';
 
 describe('LogViewer callback triggers', () => {
   let tmpHome;
@@ -28,11 +29,13 @@ describe('LogViewer callback triggers', () => {
       path.join(traceDir, 'current.jsonl'),
       JSON.stringify({ timestamp: '2025-01-01T00:00:00Z', text: 't' }) + '\n'
     );
+    setActiveProject('proj');
   });
 
   afterEach(async () => {
     process.env.HOME = oldHome;
     if (tmpHome) await fs.remove(tmpHome);
+    setActiveProject(null);
   });
 
   test('opens filter and details views via callbacks', async () => {
@@ -44,8 +47,6 @@ describe('LogViewer callback triggers', () => {
         TraceProvider,
         null,
         React.createElement(LogViewer, {
-          project: 'proj',
-          config: {},
           onBack: () => {},
           onExit: () => {},
           onOpenFilter: () => {

--- a/test/tui/log-viewer-tail.test.js
+++ b/test/tui/log-viewer-tail.test.js
@@ -7,6 +7,7 @@ import path from 'path';
 import os from 'os';
 import { TraceProvider } from '../../src/tui/contexts/trace-context.js';
 import { LogViewer } from '../../src/tui/views/log-viewer.js';
+import { setActiveProject } from '../../src/tui/stores/project-store.js';
 
 describe('LogViewer default selection', () => {
   let tmpHome;
@@ -33,11 +34,13 @@ describe('LogViewer default selection', () => {
         JSON.stringify({ timestamp: '2025-01-01T00:00:02Z', text: 't3' }) +
         '\n'
     );
+    setActiveProject('proj');
   });
 
   afterEach(async () => {
     process.env.HOME = oldHome;
     if (tmpHome) await fs.remove(tmpHome);
+    setActiveProject(null);
   });
 
   test('selects last trace on load', async () => {
@@ -47,8 +50,6 @@ describe('LogViewer default selection', () => {
         TraceProvider,
         null,
         React.createElement(LogViewer, {
-          project: 'proj',
-          config: {},
           onBack: () => {},
           onExit: () => {},
           onOpenDetails: ({ currentIndex }) => {


### PR DESCRIPTION
## Summary
- add project, config and filter stores using nanostores
- update TUI app and views to use the new stores
- adjust tests for store-based APIs

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_683b5803bc0c8324a51cc179aa66b7e0