### PR TITLE
Implement global UI store and footer

### DIFF
--- a/src/tui/components/footer.js
+++ b/src/tui/components/footer.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Text } from 'ink';
+import { useStore } from '@nanostores/react';
+import { $uiState } from '../stores/ui-store.js';
+import { SHORTCUTS, buildFooter } from '../ui-utils/constants.js';
+
+export const Footer = () => {
+  const { activeView } = useStore($uiState);
+  let shortcuts = [];
+  switch (activeView) {
+    case 'selector':
+      shortcuts = [SHORTCUTS.NAVIGATE, SHORTCUTS.OPEN, SHORTCUTS.QUIT];
+      break;
+    case 'log':
+      shortcuts = [
+        SHORTCUTS.NAVIGATE,
+        SHORTCUTS.DETAIL,
+        SHORTCUTS.PAGE,
+        SHORTCUTS.TOP_BOTTOM,
+        SHORTCUTS.FILTER,
+        SHORTCUTS.REFRESH,
+        SHORTCUTS.BACK_B,
+        SHORTCUTS.QUIT,
+      ];
+      break;
+    case 'details':
+      shortcuts = [
+        SHORTCUTS.LINE,
+        SHORTCUTS.PAGE,
+        SHORTCUTS.TOP_BOTTOM,
+        SHORTCUTS.PREV_NEXT,
+        SHORTCUTS.EXIT,
+      ];
+      break;
+    case 'filter':
+      shortcuts = [
+        SHORTCUTS.NAVIGATE,
+        SHORTCUTS.TOGGLE,
+        SHORTCUTS.APPLY,
+        SHORTCUTS.EXIT,
+      ];
+      break;
+    default:
+      break;
+  }
+  return React.createElement(
+    Text,
+    { dimColor: true, wrap: 'truncate-end' },
+    buildFooter(...shortcuts)
+  );
+};

--- a/src/tui/hooks/use-global-keys.js
+++ b/src/tui/hooks/use-global-keys.js
@@ -1,0 +1,12 @@
+import { useInput } from 'ink';
+import { dispatch } from '../stores/ui-store.js';
+
+export const useGlobalKeys = () => {
+  useInput((input) => {
+    if (input === 'q') {
+      dispatch({ type: 'quit' });
+    } else if (input === 'b') {
+      dispatch({ type: 'back' });
+    }
+  });
+};

--- a/src/tui/stores/ui-store.js
+++ b/src/tui/stores/ui-store.js
@@ -1,0 +1,40 @@
+import { map } from 'nanostores';
+import { dispatch as traceDispatch } from './trace-selection-store.js';
+import { setActiveProject } from './project-store.js';
+
+export const $uiState = map({ activeView: 'selector' });
+
+export function dispatch(action) {
+  const { activeView } = $uiState.get();
+  switch (action.type) {
+    case 'set-view':
+      $uiState.setKey('activeView', action.view);
+      break;
+    case 'close-details':
+      traceDispatch({ type: 'close-details' });
+      $uiState.setKey('activeView', 'log');
+      break;
+    case 'back':
+      if (activeView === 'details') {
+        traceDispatch({ type: 'close-details' });
+        $uiState.setKey('activeView', 'log');
+      } else if (activeView === 'filter') {
+        $uiState.setKey('activeView', 'log');
+      } else if (activeView === 'log') {
+        setActiveProject(null);
+        $uiState.setKey('activeView', 'selector');
+      } else if (activeView === 'selector') {
+        process.exit(0);
+      }
+      break;
+    case 'quit':
+      process.exit(0);
+      break;
+    default:
+      break;
+  }
+}
+
+export function setActiveView(view) {
+  dispatch({ type: 'set-view', view });
+}

--- a/src/tui/ui-utils/constants.js
+++ b/src/tui/ui-utils/constants.js
@@ -29,7 +29,7 @@ export const SHORTCUTS = /** @type {const} */ ({
   FILTER: '[f] Filter',
   BACK_B: '[b] Back',
   PREV_NEXT: '[←/→] Prev/Next',
-  EXIT: '[Enter/Esc/q] Back',
+  EXIT: '[Enter/Esc/b] Back',
   QUIT: '[q] Quit',
 });
 

--- a/src/tui/ui-utils/text-utils.js
+++ b/src/tui/ui-utils/text-utils.js
@@ -84,6 +84,6 @@ export const sanitizeText = (text) => {
 
 export const isEnterKey = (key) => !!(key && key.return);
 export const isBackKey = (input, key) =>
-  !!((key && key.escape) || input === 'q');
+  !!((key && key.escape) || input === 'b');
 export const isExitKey = (input, key) =>
   isEnterKey(key) || isBackKey(input, key);

--- a/src/tui/views/project-selector.js
+++ b/src/tui/views/project-selector.js
@@ -1,20 +1,14 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Text, useInput } from 'ink';
+import { Box, Text } from 'ink';
 import { Select } from '@inkjs/ui';
 import { AppContainer } from '../components/app-container.js';
-import { SHORTCUTS, buildFooter } from '../ui-utils/constants.js';
-import { isBackKey } from '../ui-utils/text-utils.js';
+import { Footer } from '../components/footer.js';
 import { discoverProjects } from '../ui-utils/project-discovery.js';
 import { setActiveProject } from '../stores/project-store.js';
+import { dispatch as uiDispatch } from '../stores/ui-store.js';
 
-export const ProjectSelector = ({ onSelect, onExit }) => {
+export const ProjectSelector = () => {
   const [projects, setProjects] = useState([]);
-
-  useInput((input, key) => {
-    if (isBackKey(input, key)) {
-      onExit();
-    }
-  });
 
   useEffect(() => {
     discoverProjects()
@@ -42,11 +36,7 @@ export const ProjectSelector = ({ onSelect, onExit }) => {
         ? 'DockaShell TUI - Select Project'
         : 'DockaShell TUI - No Projects Found'
     ),
-    footer: React.createElement(
-      Text,
-      { dimColor: true },
-      buildFooter(SHORTCUTS.NAVIGATE, SHORTCUTS.OPEN, SHORTCUTS.QUIT)
-    ),
+    footer: React.createElement(Footer),
     children: React.createElement(
       Box,
       { flexDirection: 'column', flexGrow: 1, width: '100%' },
@@ -55,7 +45,7 @@ export const ProjectSelector = ({ onSelect, onExit }) => {
             options,
             onChange: (value) => {
               setActiveProject(value);
-              onSelect?.(value);
+              uiDispatch({ type: 'set-view', view: 'log' });
             },
           })
         : React.createElement(

--- a/src/tui/views/trace-details-view.js
+++ b/src/tui/views/trace-details-view.js
@@ -5,7 +5,8 @@ import { useMouseInput } from '../hooks/use-mouse-input.js';
 import { AppContainer } from '../components/app-container.js';
 import { useStdoutDimensions } from '../hooks/use-stdout-dimensions.js';
 import { buildFullLines } from '../components/trace-item-preview.js';
-import { SHORTCUTS, buildFooter } from '../ui-utils/constants.js';
+import { Footer } from '../components/footer.js';
+import { dispatch as uiDispatch } from '../stores/ui-store.js';
 import { isExitKey } from '../ui-utils/text-utils.js';
 
 export const TraceDetailsView = () => {
@@ -18,11 +19,7 @@ export const TraceDetailsView = () => {
   if (!detailsState) {
     return React.createElement(AppContainer, {
       header: React.createElement(Text, { bold: true }, 'Trace Details'),
-      footer: React.createElement(
-        Text,
-        { dimColor: true },
-        buildFooter(SHORTCUTS.EXIT)
-      ),
+      footer: React.createElement(Footer),
       children: React.createElement(
         Box,
         { flexGrow: 1, justifyContent: 'center', alignItems: 'center' },
@@ -40,11 +37,7 @@ export const TraceDetailsView = () => {
   if (!currentTrace) {
     return React.createElement(AppContainer, {
       header: React.createElement(Text, { bold: true }, 'Trace Details'),
-      footer: React.createElement(
-        Text,
-        { dimColor: true },
-        buildFooter(SHORTCUTS.EXIT)
-      ),
+      footer: React.createElement(Footer),
       children: React.createElement(
         Box,
         { flexGrow: 1, justifyContent: 'center', alignItems: 'center' },
@@ -105,7 +98,7 @@ export const TraceDetailsView = () => {
     }
     // Close view
     else if (isExitKey(input, key)) {
-      dispatch({ type: 'close-details' });
+      uiDispatch({ type: 'close-details' });
     }
   });
 
@@ -131,17 +124,7 @@ export const TraceDetailsView = () => {
       { bold: true, wrap: 'truncate-end' },
       `Trace Details${navigationIndicator}${scrollIndicator}`
     ),
-    footer: React.createElement(
-      Text,
-      { dimColor: true, wrap: 'truncate-end' },
-      buildFooter(
-        SHORTCUTS.LINE,
-        SHORTCUTS.PAGE,
-        SHORTCUTS.TOP_BOTTOM,
-        SHORTCUTS.PREV_NEXT,
-        SHORTCUTS.EXIT
-      )
-    ),
+    footer: React.createElement(Footer),
     children: React.createElement(
       Box,
       {

--- a/src/tui/views/trace-types-filter-view.js
+++ b/src/tui/views/trace-types-filter-view.js
@@ -1,18 +1,18 @@
 import React, { useState } from 'react';
-import { useInput, Text } from 'ink';
+import { Text } from 'ink';
 import { MultiSelect } from '@inkjs/ui';
 import { useStdoutDimensions } from '../hooks/use-stdout-dimensions.js';
 import { AppContainer } from '../components/app-container.js';
 import { useStore } from '@nanostores/react';
 import { DEFAULT_FILTERS } from '../ui-utils/entry-utils.js';
 import { $traceFilters, setTraceFilters } from '../stores/filter-store.js';
-import { SHORTCUTS, buildFooter } from '../ui-utils/constants.js';
-import { isBackKey } from '../ui-utils/text-utils.js';
+import { Footer } from '../components/footer.js';
+import { dispatch as uiDispatch } from '../stores/ui-store.js';
 
 /**
  * Full screen trace type filter view using ink-ui MultiSelect.
  */
-export const TraceTypesFilterView = ({ onBack }) => {
+export const TraceTypesFilterView = () => {
   const [, terminalHeight] = useStdoutDimensions();
 
   const traceTypes = [
@@ -51,14 +51,8 @@ export const TraceTypesFilterView = ({ onBack }) => {
   const handleSubmit = (finalValues) => {
     const newFilters = arrayToFilters(finalValues);
     setTraceFilters(newFilters);
-    onBack?.();
+    uiDispatch({ type: 'set-view', view: 'log' });
   };
-
-  useInput((input, key) => {
-    if (isBackKey(input, key)) {
-      onBack();
-    }
-  });
 
   return React.createElement(AppContainer, {
     header: React.createElement(
@@ -66,16 +60,7 @@ export const TraceTypesFilterView = ({ onBack }) => {
       { bold: true },
       'DockaShell TUI - Filter Trace Types'
     ),
-    footer: React.createElement(
-      Text,
-      { dimColor: true },
-      buildFooter(
-        SHORTCUTS.NAVIGATE,
-        SHORTCUTS.TOGGLE,
-        SHORTCUTS.APPLY,
-        SHORTCUTS.EXIT
-      )
-    ),
+    footer: React.createElement(Footer),
     children: React.createElement(MultiSelect, {
       options: traceTypes,
       defaultValue: selectedValues,

--- a/test/tui/input-utils.test.js
+++ b/test/tui/input-utils.test.js
@@ -12,8 +12,8 @@ describe('input utils', () => {
     assert.ok(!isEnterKey({}));
   });
 
-  test('isBackKey detects escape and q', () => {
-    assert.ok(isBackKey('q', {}));
+  test('isBackKey detects escape and b', () => {
+    assert.ok(isBackKey('b', {}));
     assert.ok(isBackKey('', { escape: true }));
     assert.ok(!isBackKey('x', {}));
   });
@@ -21,7 +21,7 @@ describe('input utils', () => {
   test('isExitKey combines checks', () => {
     assert.ok(isExitKey('', { return: true }));
     assert.ok(isExitKey('', { escape: true }));
-    assert.ok(isExitKey('q', {}));
+    assert.ok(isExitKey('b', {}));
     assert.ok(!isExitKey('x', {}));
   });
 });

--- a/test/tui/log-viewer-callbacks.test.js
+++ b/test/tui/log-viewer-callbacks.test.js
@@ -8,6 +8,7 @@ import os from 'os';
 import { resetTraceSelection } from '../../src/tui/stores/trace-selection-store.js';
 import { LogViewer } from '../../src/tui/views/log-viewer.js';
 import { setActiveProject } from '../../src/tui/stores/project-store.js';
+import { $uiState } from '../../src/tui/stores/ui-store.js';
 
 describe('LogViewer callback triggers', () => {
   let tmpHome;
@@ -38,32 +39,16 @@ describe('LogViewer callback triggers', () => {
     setActiveProject(null);
   });
 
-  test('opens filter and details views via callbacks', async () => {
-    let filterCalled = false;
-    let detailCalled = false;
-    let detailIndex = null;
+  test('updates activeView on key presses', async () => {
     resetTraceSelection();
-    const { stdin, unmount } = render(
-      React.createElement(LogViewer, {
-        onBack: () => {},
-        onExit: () => {},
-        onOpenFilter: () => {
-          filterCalled = true;
-        },
-        onOpenDetails: ({ currentIndex }) => {
-          detailCalled = true;
-          detailIndex = currentIndex;
-        },
-      })
-    );
+    const { stdin, unmount } = render(React.createElement(LogViewer));
     await new Promise((r) => setTimeout(r, 50));
     stdin.write('f');
     await new Promise((r) => setTimeout(r, 20));
-    assert.ok(filterCalled);
+    assert.strictEqual($uiState.get().activeView, 'filter');
     stdin.write('\r');
     await new Promise((r) => setTimeout(r, 20));
-    assert.ok(detailCalled);
-    assert.strictEqual(detailIndex, 0);
+    assert.strictEqual($uiState.get().activeView, 'details');
     unmount();
   });
 });

--- a/test/tui/log-viewer-tail.test.js
+++ b/test/tui/log-viewer-tail.test.js
@@ -8,6 +8,8 @@ import os from 'os';
 import { resetTraceSelection } from '../../src/tui/stores/trace-selection-store.js';
 import { LogViewer } from '../../src/tui/views/log-viewer.js';
 import { setActiveProject } from '../../src/tui/stores/project-store.js';
+import { $traceSelection } from '../../src/tui/stores/trace-selection-store.js';
+import { $uiState } from '../../src/tui/stores/ui-store.js';
 
 describe('LogViewer default selection', () => {
   let tmpHome;
@@ -44,21 +46,13 @@ describe('LogViewer default selection', () => {
   });
 
   test('selects last trace on load', async () => {
-    let idx = null;
     resetTraceSelection();
-    const { stdin, unmount } = render(
-      React.createElement(LogViewer, {
-        onBack: () => {},
-        onExit: () => {},
-        onOpenDetails: ({ currentIndex }) => {
-          idx = currentIndex;
-        },
-      })
-    );
+    const { stdin, unmount } = render(React.createElement(LogViewer));
     await new Promise((r) => setTimeout(r, 50));
     stdin.write('\r');
     await new Promise((r) => setTimeout(r, 20));
-    assert.strictEqual(idx, 2);
+    assert.strictEqual($uiState.get().activeView, 'details');
+    assert.strictEqual($traceSelection.get().detailsState.currentIndex, 2);
     unmount();
   });
 });


### PR DESCRIPTION
## Summary
- add `ui-store` and `use-global-keys` hook for unified navigation
- render new `Footer` component using `activeView`
- refactor app and views to use `ui-store`
- update key constants and helpers
- adjust tests for updated shortcuts

## Testing
- `npm run lint:fix`
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683b66eaa23083248cf3b77460ef49fa