### PR TITLE
Refactor entry height constant

### DIFF
--- a/src/tui/components/trace-item-preview.js
+++ b/src/tui/components/trace-item-preview.js
@@ -82,8 +82,3 @@ export const TraceItemPreview = ({
     renderLine(contentLine)
   );
 };
-
-TraceItemPreview.getHeight = (entry, selected = false) => {
-  // Always 2 lines (header + content) + marginBottom + selection border
-  return 2 + 1 + (selected ? 2 : 0);
-};

--- a/src/tui/views/log-viewer.js
+++ b/src/tui/views/log-viewer.js
@@ -23,8 +23,7 @@ import { Footer } from '../components/footer.js';
 import { dispatch as uiDispatch } from '../stores/ui-store.js';
 import { isEnterKey } from '../ui-utils/text-utils.js';
 
-export const getEntryHeight = (entry, isSelected) =>
-  TraceItemPreview.getHeight(entry.trace, isSelected);
+export const getEntryHeight = (isSelected) => 3 + (isSelected ? 2 : 0);
 
 export const LogViewer = () => {
   // Get selection state from store
@@ -53,7 +52,7 @@ export const LogViewer = () => {
   const list = useVirtualList({
     totalCount: filteredEntries.length,
     getItem: (idx) => filteredEntries[idx],
-    getItemHeight: (item, selected) => getEntryHeight(item, selected),
+    getItemHeight: (_, selected) => getEntryHeight(selected),
     initialIndex: selectedIndex,
     initialOffset: scrollOffset,
   });
@@ -242,8 +241,8 @@ export const LogViewer = () => {
     } else if (evt.button === 'left' && !evt.isRelease) {
       const startRow = 2; // header + marginTop
       let r = evt.y - startRow;
-      for (const { item, index } of list.visibleItems) {
-        const h = getEntryHeight(item, index === listSelectedIndex);
+      for (const { index } of list.visibleItems) {
+        const h = getEntryHeight(index === listSelectedIndex);
         if (r < h) {
           traceDispatch({ type: 'set-index', index, traces: filteredEntries });
           ensureVisible(index);

--- a/test/tui/log-viewer-utils.test.js
+++ b/test/tui/log-viewer-utils.test.js
@@ -1,8 +1,7 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert';
 // Simplified height function used for visibility calculations in tests
-const getEntryHeight = (entry, selected) =>
-  (entry.height || 3) + (selected ? 2 : 0);
+const getEntryHeight = (selected) => 3 + (selected ? 2 : 0);
 
 const ensureVisible = (entries, terminalHeight, scrollOffset, index) => {
   if (entries.length === 0) return scrollOffset;
@@ -13,7 +12,7 @@ const ensureVisible = (entries, terminalHeight, scrollOffset, index) => {
     const availableHeight = terminalHeight - 3;
     let height = 0;
     for (let i = index; i >= offset; i--) {
-      height += getEntryHeight(entries[i], i === index);
+      height += getEntryHeight(i === index);
       if (height > availableHeight) {
         offset = i + 1;
         break;
@@ -36,10 +35,9 @@ const calculateVisible = (
   let end = scrollOffset;
   while (
     end < entries.length &&
-    height + getEntryHeight(entries[end], end === selectedIndex) <=
-      availableHeight
+    height + getEntryHeight(end === selectedIndex) <= availableHeight
   ) {
-    height += getEntryHeight(entries[end], end === selectedIndex);
+    height += getEntryHeight(end === selectedIndex);
     end++;
   }
   return { start: scrollOffset, end, height };
@@ -51,10 +49,9 @@ const initialOffset = (entries, terminalHeight, selectedIndex) => {
   const availableHeight = terminalHeight - 3;
   while (
     offset >= 0 &&
-    height + getEntryHeight(entries[offset], offset === selectedIndex) <=
-      availableHeight
+    height + getEntryHeight(offset === selectedIndex) <= availableHeight
   ) {
-    height += getEntryHeight(entries[offset], offset === selectedIndex);
+    height += getEntryHeight(offset === selectedIndex);
     offset--;
   }
   offset = Math.max(0, Math.min(entries.length - 1, offset + 1));
@@ -63,13 +60,13 @@ const initialOffset = (entries, terminalHeight, selectedIndex) => {
 
 describe('LogViewer visibility logic', () => {
   test('scroll offset clamps when entry exceeds viewport', () => {
-    const entries = [{ height: 20 }];
-    const off = initialOffset(entries, 10, 0);
+    const entries = [{}];
+    const off = initialOffset(entries, 7, 0);
     assert.strictEqual(off, 0);
   });
 
   test('visible entries remain complete while navigating', () => {
-    const entries = [{ height: 3 }, { height: 5 }, { height: 3 }];
+    const entries = [{}, {}, {}];
     const termHeight = 10;
     let selected = 2;
     let offset = initialOffset(entries, termHeight, selected);


### PR DESCRIPTION
## Summary
- drop `TraceItemPreview.getHeight` helper
- hard-code entry height in `getEntryHeight`

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_683b755159048324a5546b7bc423fdd3