### PR TITLE
Centralize footer component

### DIFF
--- a/src/tui/app.js
+++ b/src/tui/app.js
@@ -1,6 +1,8 @@
 import React, { useEffect } from 'react';
+import { Box } from 'ink';
 import { useTerminalMouseMode } from './hooks/use-terminal-mouse-mode.js';
 import { useGlobalKeys } from './hooks/use-global-keys.js';
+import { useStdoutDimensions } from './hooks/use-stdout-dimensions.js';
 import { ProjectSelector } from './views/project-selector.js';
 import { LogViewer } from './views/log-viewer.js';
 import { TraceDetailsView } from './views/trace-details-view.js';
@@ -10,6 +12,7 @@ import { $activeProject, setActiveProject } from './stores/project-store.js';
 import { $appConfig } from './stores/config-store.js';
 import { $traceFilters } from './stores/filter-store.js';
 import { $uiState, dispatch as uiDispatch } from './stores/ui-store.js';
+import { Footer } from './components/footer.js';
 
 /**
  * Main application component that uses trace context
@@ -57,5 +60,11 @@ const MainApp = ({ projectArg }) => {
  * Root App component that provides trace selection context
  */
 export const App = ({ projectArg }) => {
-  return React.createElement(MainApp, { projectArg });
+  const [, height] = useStdoutDimensions();
+  return React.createElement(
+    Box,
+    { flexDirection: 'column', height, width: '100%' },
+    React.createElement(MainApp, { projectArg }),
+    React.createElement(Box, { flexShrink: 0 }, React.createElement(Footer))
+  );
 };

--- a/src/tui/components/app-container.js
+++ b/src/tui/components/app-container.js
@@ -1,23 +1,20 @@
 import React from 'react';
 import { Box } from 'ink';
-import { useStdoutDimensions } from '../hooks/use-stdout-dimensions.js';
 
 /**
- * Standard full screen layout with header and footer.
- * Takes entire terminal space with no padding and optional spacing
- * between sections.
+ * Standard full screen layout with header.
+ * Takes entire terminal space with no padding and optional spacing between
+ * sections.
  */
-export const AppContainer = ({ header, footer, children }) => {
-  const [, height] = useStdoutDimensions();
+export const AppContainer = ({ header, children }) => {
   return React.createElement(
     Box,
-    { flexDirection: 'column', height, width: '100%' },
+    { flexDirection: 'column', flexGrow: 1, width: '100%' },
     React.createElement(Box, { flexShrink: 0 }, header),
     React.createElement(
       Box,
       { flexGrow: 1, marginTop: 1, marginBottom: 1, width: '100%' },
       children
-    ),
-    React.createElement(Box, { flexShrink: 0 }, footer)
+    )
   );
 };

--- a/src/tui/views/log-viewer.js
+++ b/src/tui/views/log-viewer.js
@@ -19,7 +19,6 @@ import { TraceItemPreview } from '../components/trace-item-preview.js';
 import { useStdoutDimensions } from '../hooks/use-stdout-dimensions.js';
 import { useVirtualList } from '../hooks/use-virtual-list.js';
 import { ScrollableList } from '../components/scrollable-list.js';
-import { Footer } from '../components/footer.js';
 import { dispatch as uiDispatch } from '../stores/ui-store.js';
 import { isEnterKey } from '../ui-utils/text-utils.js';
 
@@ -270,7 +269,6 @@ export const LogViewer = () => {
       { bold: true, wrap: 'truncate-end' },
       `DockaShell TUI - ${project}${scrollIndicator}`
     ),
-    footer: React.createElement(Footer),
     children: React.createElement(ScrollableList, {
       list,
       renderItem: (entry, index, selected) =>

--- a/src/tui/views/project-selector.js
+++ b/src/tui/views/project-selector.js
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { Box, Text } from 'ink';
 import { Select } from '@inkjs/ui';
 import { AppContainer } from '../components/app-container.js';
-import { Footer } from '../components/footer.js';
 import { discoverProjects } from '../ui-utils/project-discovery.js';
 import { setActiveProject } from '../stores/project-store.js';
 import { dispatch as uiDispatch } from '../stores/ui-store.js';
@@ -36,7 +35,6 @@ export const ProjectSelector = () => {
         ? 'DockaShell TUI - Select Project'
         : 'DockaShell TUI - No Projects Found'
     ),
-    footer: React.createElement(Footer),
     children: React.createElement(
       Box,
       { flexDirection: 'column', flexGrow: 1, width: '100%' },

--- a/src/tui/views/trace-details-view.js
+++ b/src/tui/views/trace-details-view.js
@@ -9,7 +9,6 @@ import { useMouseInput } from '../hooks/use-mouse-input.js';
 import { AppContainer } from '../components/app-container.js';
 import { useStdoutDimensions } from '../hooks/use-stdout-dimensions.js';
 import { buildFullLines } from '../components/trace-item-preview.js';
-import { Footer } from '../components/footer.js';
 import { dispatch as uiDispatch } from '../stores/ui-store.js';
 import { isExitKey } from '../ui-utils/text-utils.js';
 
@@ -20,7 +19,6 @@ export const TraceDetailsView = () => {
   if (!detailsState) {
     return React.createElement(AppContainer, {
       header: React.createElement(Text, { bold: true }, 'Trace Details'),
-      footer: React.createElement(Footer),
       children: React.createElement(
         Box,
         { flexGrow: 1, justifyContent: 'center', alignItems: 'center' },
@@ -38,7 +36,6 @@ export const TraceDetailsView = () => {
   if (!currentTrace) {
     return React.createElement(AppContainer, {
       header: React.createElement(Text, { bold: true }, 'Trace Details'),
-      footer: React.createElement(Footer),
       children: React.createElement(
         Box,
         { flexGrow: 1, justifyContent: 'center', alignItems: 'center' },
@@ -125,7 +122,6 @@ export const TraceDetailsView = () => {
       { bold: true, wrap: 'truncate-end' },
       `Trace Details${navigationIndicator}${scrollIndicator}`
     ),
-    footer: React.createElement(Footer),
     children: React.createElement(
       Box,
       {

--- a/src/tui/views/trace-types-filter-view.js
+++ b/src/tui/views/trace-types-filter-view.js
@@ -6,7 +6,6 @@ import { AppContainer } from '../components/app-container.js';
 import { useStore } from '@nanostores/react';
 import { DEFAULT_FILTERS } from '../ui-utils/entry-utils.js';
 import { $traceFilters, setTraceFilters } from '../stores/filter-store.js';
-import { Footer } from '../components/footer.js';
 import { dispatch as uiDispatch } from '../stores/ui-store.js';
 
 /**
@@ -60,7 +59,6 @@ export const TraceTypesFilterView = () => {
       { bold: true },
       'DockaShell TUI - Filter Trace Types'
     ),
-    footer: React.createElement(Footer),
     children: React.createElement(MultiSelect, {
       options: traceTypes,
       defaultValue: selectedValues,

--- a/test/tui/views/project-selector/project-selector.test.js
+++ b/test/tui/views/project-selector/project-selector.test.js
@@ -48,8 +48,6 @@ describe('ProjectSelector ink-ui integration', () => {
     await new Promise((r) => setTimeout(r, 50));
     const frame = lastFrame();
     assert.ok(frame.includes('proj'));
-    assert.ok(frame.includes('[↑↓] Navigate'));
-    assert.ok(frame.includes('[Enter] Open'));
   });
 
   test('lists project with only archived sessions', async () => {


### PR DESCRIPTION
## Summary
- centralize the `Footer` component by rendering it once in `App`
- remove `footer` prop from `AppContainer`
- drop footer usage from views
- update project selector test

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_683b78dd3b888324bace43de8f133a69