### PR TITLE
Add trace buffer store for TUI

### DIFF
--- a/src/tui/stores/project-store.js
+++ b/src/tui/stores/project-store.js
@@ -1,7 +1,11 @@
 import { atom } from 'nanostores';
+import { $appConfig } from './config-store.js';
+import { initTraceBuffer } from './trace-buffer-store.js';
 
 export const $activeProject = atom(null);
 
 export function setActiveProject(name) {
   $activeProject.set(name);
+  const maxEntries = $appConfig.get().tui?.display?.max_entries || 100;
+  initTraceBuffer(name, maxEntries);
 }

--- a/src/tui/stores/trace-buffer-store.js
+++ b/src/tui/stores/trace-buffer-store.js
@@ -1,0 +1,54 @@
+import { atom, computed } from 'nanostores';
+import { TraceBuffer } from '../ui-utils/trace-buffer.js';
+import { detectTraceType } from '../ui-utils/entry-utils.js';
+import { $traceFilters } from './filter-store.js';
+
+export const $traceBuffer = atom(null);
+export const $traceEntries = atom([]);
+
+export const $filteredEntries = computed(
+  [$traceEntries, $traceFilters],
+  (entries, filters) =>
+    entries.filter((entry) => {
+      const type = detectTraceType(entry.trace);
+      return filters[type] !== false;
+    })
+);
+
+let activeProject = null;
+let unsubscribe = null;
+
+export async function initTraceBuffer(project, maxEntries = 100) {
+  if (project === activeProject && $traceBuffer.get()) {
+    return;
+  }
+
+  if (unsubscribe) {
+    unsubscribe();
+    unsubscribe = null;
+  }
+
+  const prev = $traceBuffer.get();
+  if (prev) {
+    await prev.close().catch(() => {});
+  }
+
+  activeProject = project;
+  if (!project) {
+    $traceBuffer.set(null);
+    $traceEntries.set([]);
+    return;
+  }
+
+  const buffer = new TraceBuffer(project, maxEntries);
+  $traceBuffer.set(buffer);
+
+  const update = () => {
+    const raw = buffer.getTraces();
+    $traceEntries.set(raw.map((e) => ({ trace: e })));
+  };
+
+  unsubscribe = buffer.onUpdate(update);
+  buffer.start().catch(() => {});
+  update();
+}

--- a/src/tui/views/trace-details-view.js
+++ b/src/tui/views/trace-details-view.js
@@ -5,6 +5,7 @@ import {
   $traceSelection,
   dispatch as traceDispatch,
 } from '../stores/trace-selection-store.js';
+import { $filteredEntries } from '../stores/trace-buffer-store.js';
 import { useMouseInput } from '../hooks/use-mouse-input.js';
 import { AppContainer } from '../components/app-container.js';
 import { useStdoutDimensions } from '../hooks/use-stdout-dimensions.js';
@@ -15,6 +16,7 @@ import { isExitKey } from '../ui-utils/text-utils.js';
 export const TraceDetailsView = () => {
   // Get details state from store
   const { detailsState } = useStore($traceSelection);
+  const traces = useStore($filteredEntries);
 
   if (!detailsState) {
     return React.createElement(AppContainer, {
@@ -27,7 +29,7 @@ export const TraceDetailsView = () => {
     });
   }
 
-  const { traces, currentIndex } = detailsState;
+  const { currentIndex } = detailsState;
 
   const [scrollOffset, setScrollOffset] = useState(0);
   const [terminalWidth, height] = useStdoutDimensions();


### PR DESCRIPTION
## Summary
- keep a TraceBuffer running between views
- add `$filteredEntries` and load traces through a store
- refresh TraceDetailsView to read from filtered store
- use trace buffer store in project-store

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_b_683b811d6f0883248a51be3a3e18e5a6