### PR TITLE
Refactor log viewer state

### DIFF
--- a/src/tui/hooks/use-virtual-list.js
+++ b/src/tui/hooks/use-virtual-list.js
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
+import { useCallback, useMemo, useRef, useEffect } from 'react';
 import { useStdoutDimensions } from './use-stdout-dimensions.js';
 
 /**
@@ -16,12 +16,12 @@ export const useVirtualList = ({
   totalCount,
   getItem,
   getItemHeight,
-  initialIndex = 0,
-  initialOffset = 0,
+  selectedIndex,
+  scrollOffset,
+  onSelectionChange,
+  onScrollChange,
 }) => {
   const [, terminalHeight] = useStdoutDimensions();
-  const [selectedIndex, setSelectedIndex] = useState(initialIndex);
-  const [scrollOffset, setScrollOffset] = useState(initialOffset);
   const cacheRef = useRef(new Map());
 
   useEffect(() => {
@@ -59,9 +59,16 @@ export const useVirtualList = ({
         }
       }
       offset = Math.min(Math.max(offset, 0), Math.max(0, totalCount - 1));
-      setScrollOffset(offset);
+      if (offset !== scrollOffset) onScrollChange?.(offset);
     },
-    [scrollOffset, terminalHeight, totalCount, getCachedItem, getItemHeight]
+    [
+      scrollOffset,
+      terminalHeight,
+      totalCount,
+      getCachedItem,
+      getItemHeight,
+      onScrollChange,
+    ]
   );
 
   const calculateVisibleRange = useCallback(() => {
@@ -107,9 +114,9 @@ export const useVirtualList = ({
     visibleStart,
     visibleEnd,
     selectedIndex,
-    setSelectedIndex,
+    setSelectedIndex: onSelectionChange,
     scrollOffset,
-    setScrollOffset,
+    setScrollOffset: onScrollChange,
     ensureVisible,
     pageSize,
   };

--- a/src/tui/stores/trace-buffer-store.js
+++ b/src/tui/stores/trace-buffer-store.js
@@ -1,4 +1,4 @@
-import { atom, computed } from 'nanostores';
+import { atom, computed, map } from 'nanostores';
 import { TraceBuffer } from '../ui-utils/trace-buffer.js';
 import { detectTraceType } from '../ui-utils/entry-utils.js';
 import { $traceFilters } from './filter-store.js';
@@ -13,6 +13,23 @@ export const $filteredEntries = computed(
       const type = detectTraceType(entry.trace);
       return filters[type] !== false;
     })
+);
+
+export const $traceState = map({
+  selectedIndex: 0,
+  scrollOffset: 0,
+  selectedTimestamp: null,
+});
+
+export const $traceData = computed(
+  [$traceEntries, $filteredEntries, $traceState],
+  (entries, filtered, state) => ({
+    entries,
+    filteredEntries: filtered,
+    selectedIndex: state.selectedIndex,
+    scrollOffset: state.scrollOffset,
+    selectedTimestamp: state.selectedTimestamp,
+  })
 );
 
 let activeProject = null;

--- a/test/tui/use-virtual-list.test.js
+++ b/test/tui/use-virtual-list.test.js
@@ -1,6 +1,6 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert';
-import React from 'react';
+import React, { useState } from 'react';
 import { render } from 'ink-testing-library';
 import { useVirtualList } from '../../src/tui/hooks/use-virtual-list.js';
 
@@ -10,10 +10,16 @@ describe('useVirtualList hook', () => {
     const items = Array.from({ length: 5 }, () => ({ height: 2 }));
     let list;
     const Test = () => {
+      const [index, setIndex] = useState(0);
+      const [offset, setOffset] = useState(0);
       list = useVirtualList({
         totalCount: items.length,
         getItem: (i) => items[i],
         getItemHeight: (it) => it.height,
+        selectedIndex: index,
+        scrollOffset: offset,
+        onSelectionChange: setIndex,
+        onScrollChange: setOffset,
       });
       return null;
     };
@@ -34,10 +40,16 @@ describe('useVirtualList hook', () => {
     const items = [];
     let list;
     const Test = () => {
+      const [index, setIndex] = useState(0);
+      const [offset, setOffset] = useState(0);
       list = useVirtualList({
         totalCount: items.length,
         getItem: (i) => items[i],
         getItemHeight: () => 1,
+        selectedIndex: index,
+        scrollOffset: offset,
+        onSelectionChange: setIndex,
+        onScrollChange: setOffset,
       });
       return null;
     };
@@ -53,10 +65,16 @@ describe('useVirtualList hook', () => {
     const items = Array.from({ length: 3 }, () => ({ height: 1 }));
     let list;
     const Test = () => {
+      const [index, setIndex] = useState(0);
+      const [offset, setOffset] = useState(0);
       list = useVirtualList({
         totalCount: items.length,
         getItem: (i) => items[i],
         getItemHeight: () => 1,
+        selectedIndex: index,
+        scrollOffset: offset,
+        onSelectionChange: setIndex,
+        onScrollChange: setOffset,
       });
       return null;
     };
@@ -73,12 +91,16 @@ describe('useVirtualList hook', () => {
     const items = Array.from({ length: 10 }, () => ({ height: 1 }));
     let list;
     const Test = () => {
+      const [index, setIndex] = useState(5);
+      const [offset, setOffset] = useState(3);
       list = useVirtualList({
         totalCount: items.length,
         getItem: (i) => items[i],
         getItemHeight: () => 1,
-        initialIndex: 5,
-        initialOffset: 3,
+        selectedIndex: index,
+        scrollOffset: offset,
+        onSelectionChange: setIndex,
+        onScrollChange: setOffset,
       });
       return null;
     };


### PR DESCRIPTION
## Summary
- unify trace state in `trace-buffer-store`
- update trace-selection store to delegate selection fields
- revise virtual list hook to accept controlled state
- simplify log viewer to use new stores
- update `use-virtual-list` tests

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_683b8474a86c8324b611cdd0e96b3ec9