### PR TITLE
Rename run_command tool to bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,25 +104,25 @@ list_projects();
 start_project({ project_name: 'web-app' });
 
 // 3. Initialize a new Node.js project
-run_command({
+bash({
   project_name: 'web-app',
   command: 'npm init -y',
 });
 
 // 4. Install dependencies
-run_command({
+bash({
   project_name: 'web-app',
   command: 'npm install express',
 });
 
 // 5. Create a simple server
-run_command({
+bash({
   project_name: 'web-app',
   command: 'echo \'const express = require("express"); const app = express(); app.get("/", (req, res) => res.send("Hello World!")); app.listen(3000);\' > app.js',
 });
 
 // 6. Start the server
-run_command({
+bash({
   project_name: 'web-app',
   command: 'node app.js',
 });
@@ -176,7 +176,7 @@ Lists all configured projects with their status.
 
 **Arguments:** `{"project_name": "string"}` Starts a Docker container for the specified project.
 
-### `run_command`
+### `bash`
 
 **Arguments:** `{"project_name": "string", "command": "string"}` Executes a shell command in the project container.
 
@@ -254,7 +254,7 @@ Agent traces are stored in `~/.dockashell/projects/{project-name}/traces/current
 ```
 {"id":"tr_abc123","tool":"start_project","trace_type":"execution","project_name":"web-app","result":{"success":true}}
 {"id":"tr_def456","tool":"write_trace","trace_type":"observation","type":"agent","text":"Planning React app"}
-{"id":"tr_ghi789","tool":"run_command","trace_type":"execution","command":"npm start","result":{"exitCode":0,"duration":"0.1s"}}
+{"id":"tr_ghi789","tool":"bash","trace_type":"execution","command":"npm start","result":{"exitCode":0,"duration":"0.1s"}}
 ```
 
 Use `write_trace` to store notes and `read_traces` to query previous entries.

--- a/docs/apply-patch-tool.md
+++ b/docs/apply-patch-tool.md
@@ -91,7 +91,7 @@ The `apply_patch` tool enables flexible, incremental file updates using the Open
 - ✅ Modifying functions, classes, or configuration sections
 - ✅ Creating new files or deleting existing ones
 - ✅ Moving files with content changes
-- ❌ Large file restructuring (use `run_command` with text editors instead)
+- ❌ Large file restructuring (use `bash` with text editors instead)
 
 ### Error Recovery
 

--- a/scripts/setup/create-examples.js
+++ b/scripts/setup/create-examples.js
@@ -182,13 +182,13 @@ async function createExampleProjects() {
   console.log('   Tool: list_projects');
   console.log('   Tool: start_project, Args: {"project_name": "web-app"}');
   console.log(
-    '   Tool: run_command, Args: {"project_name": "web-app", "command": "node --version"}'
+    '   Tool: bash, Args: {"project_name": "web-app", "command": "node --version"}'
   );
   console.log(
-    '   Tool: run_command, Args: {"project_name": "web-app", "command": "python3 --version"}'
+    '   Tool: bash, Args: {"project_name": "web-app", "command": "python3 --version"}'
   );
   console.log(
-    '   Tool: run_command, Args: {"project_name": "web-app", "command": "which rg"}'
+    '   Tool: bash, Args: {"project_name": "web-app", "command": "which rg"}'
   );
 }
 

--- a/src/mcp/tools/execution-tools.js
+++ b/src/mcp/tools/execution-tools.js
@@ -9,7 +9,7 @@ export function registerExecutionTools(
 ) {
   // Run command
   server.tool(
-    'run_command',
+    'bash',
     {
       project_name: z.string().describe('Name of the project'),
       command: z.string().describe('Shell command to execute'),

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -82,7 +82,7 @@ class Logger {
         command: (command || '').substring(0, 50),
       });
       const recorder = await this.getTraceRecorder(projectName);
-      await recorder.execution('run_command', { command }, logResult);
+      await recorder.execution('bash', { command }, logResult);
     } catch (error) {
       console.error('Failed to log command:', error.message);
       // Don't throw - logging failures shouldn't break the main operation

--- a/src/utils/trace-utils.js
+++ b/src/utils/trace-utils.js
@@ -1,7 +1,7 @@
 export function parseTraceLine(line) {
   try {
     const trace = JSON.parse(line);
-    if (trace.tool === 'run_command') {
+    if (trace.tool === 'bash' || trace.tool === 'run_command') {
       return {
         timestamp: trace.timestamp,
         kind: 'command',

--- a/test/integration/test-mcp-tools.js
+++ b/test/integration/test-mcp-tools.js
@@ -115,24 +115,21 @@ async function testMCPTools() {
 
   // Test 4: Run command with invalid parameters
   try {
-    console.log('4. Testing run_command with empty command...');
-    const response = await runMCPCommand('run_command', {
+    console.log('4. Testing bash with empty command...');
+    const response = await runMCPCommand('bash', {
       project_name: 'test-project',
       command: '',
     });
     if (response.error || response.result?.isError) {
       console.log(
-        '✅ run_command properly rejected empty command:',
+        '✅ bash properly rejected empty command:',
         response.result?.content?.[0]?.text || response.error?.message
       );
     } else {
       console.log('❌ Should have failed with empty command');
     }
   } catch (error) {
-    console.log(
-      '✅ run_command properly rejected empty command:',
-      error.message
-    );
+    console.log('✅ bash properly rejected empty command:', error.message);
   }
 
   // Test 5: apply_patch with nonexistent project

--- a/test/mcp/execution-tools.test.js
+++ b/test/mcp/execution-tools.test.js
@@ -15,12 +15,12 @@ describe('execution-tools', () => {
   test('registers tools', () => {
     const server = createServer();
     registerExecutionTools(server, {}, {}, {});
-    assert.ok(server.tools.run_command);
+    assert.ok(server.tools.bash);
     assert.ok(server.tools.apply_patch);
     assert.ok(server.tools.write_file);
   });
 
-  test('run_command success', async () => {
+  test('bash success', async () => {
     const server = createServer();
     const pm = { loadProject: async () => ({}) };
     const cm = {
@@ -34,7 +34,7 @@ describe('execution-tools', () => {
     };
     const sm = { validateCommand: () => {}, getMaxExecutionTime: () => 1 };
     registerExecutionTools(server, pm, cm, sm);
-    const result = await server.tools.run_command.handler({
+    const result = await server.tools.bash.handler({
       project_name: 'proj',
       command: 'ls',
     });
@@ -42,7 +42,7 @@ describe('execution-tools', () => {
     assert.ok(result.content[0].text.includes('**Exit Code:** 0'));
   });
 
-  test('run_command failure response', async () => {
+  test('bash failure response', async () => {
     const server = createServer();
     const pm = { loadProject: async () => ({}) };
     const cm = {
@@ -50,18 +50,18 @@ describe('execution-tools', () => {
     };
     const sm = { validateCommand: () => {}, getMaxExecutionTime: () => 1 };
     registerExecutionTools(server, pm, cm, sm);
-    const res = await server.tools.run_command.handler({
+    const res = await server.tools.bash.handler({
       project_name: 'p',
       command: 'ls',
     });
     assert.strictEqual(res.isError, true);
   });
 
-  test('run_command invalid command throws', async () => {
+  test('bash invalid command throws', async () => {
     const server = createServer();
     registerExecutionTools(server, {}, {}, {});
     await assert.rejects(
-      server.tools.run_command.handler({ project_name: 'p', command: '' }),
+      server.tools.bash.handler({ project_name: 'p', command: '' }),
       /Command must be a non-empty string/
     );
   });

--- a/test/utils/trace-recorder.test.js
+++ b/test/utils/trace-recorder.test.js
@@ -32,11 +32,7 @@ describe('TraceRecorder', () => {
   });
 
   test('writes trace entries and moves on close', async () => {
-    await recorder.execution(
-      'run_command',
-      { command: 'echo hi' },
-      { exit: 0 }
-    );
+    await recorder.execution('bash', { command: 'echo hi' }, { exit: 0 });
     const fileExists = await fs.pathExists(recorder.currentFile);
     assert.ok(fileExists);
     await recorder.close();

--- a/test/utils/trace-utils.test.js
+++ b/test/utils/trace-utils.test.js
@@ -7,19 +7,28 @@ import {
 
 describe('trace-utils', () => {
   test('parseTraceLine handles known tools', () => {
-    const cmdLine = JSON.stringify({
+    const bashLine = JSON.stringify({
       timestamp: '2025-01-01T00:00:00Z',
-      tool: 'run_command',
+      tool: 'bash',
       command: 'echo hi',
       result: { exitCode: 0 },
     });
-    const cmd = parseTraceLine(cmdLine);
-    assert.deepStrictEqual(cmd, {
+    const bash = parseTraceLine(bashLine);
+    assert.deepStrictEqual(bash, {
       timestamp: '2025-01-01T00:00:00Z',
       kind: 'command',
       command: 'echo hi',
       result: { exitCode: 0 },
     });
+
+    const legacyLine = JSON.stringify({
+      timestamp: '2025-01-01T00:00:00Z',
+      tool: 'run_command',
+      command: 'echo hi',
+      result: { exitCode: 0 },
+    });
+    const legacy = parseTraceLine(legacyLine);
+    assert.deepStrictEqual(legacy, bash);
 
     const patchLine = JSON.stringify({
       timestamp: '2025-01-01T00:00:01Z',


### PR DESCRIPTION
## Summary
- rename `run_command` tool to `bash`
- handle legacy trace entries labeled `run_command`
- update docs and example setup script
- rename tests for new `bash` tool

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_683c813e6a8c83248bc2e62b64b6f8f7