### PR TITLE
Add DockaShell CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "main": "src/mcp/mcp-server.js",
   "bin": {
-    "dockashell": "./src/mcp/mcp-server.js",
-    "dockashell-tui": "./src/tui/tui-launcher.js"
+    "dockashell": "./src/cli/cli.js"
   },
   "scripts": {
     "start": "node src/mcp/mcp-server.js",

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { registerStatus } from './commands/status.js';
+import { registerBuild } from './commands/build.js';
+import { registerProjectCommands } from './commands/project.js';
+import { registerLogs } from './commands/logs.js';
+import { registerServe } from './commands/serve.js';
+import { registerHelp } from './commands/help.js';
+
+const program = new Command();
+
+program
+  .name('dockashell')
+  .version('0.1.0')
+  .description('AI agent secure Docker environments');
+
+registerStatus(program);
+registerBuild(program);
+registerProjectCommands(program);
+registerLogs(program);
+registerServe(program);
+registerHelp(program);
+
+program.parse(process.argv);

--- a/src/cli/commands/build.js
+++ b/src/cli/commands/build.js
@@ -1,0 +1,28 @@
+import { ImageBuilder } from '../../../scripts/image/build-default-image.js';
+import { success, error as errorColor } from '../utils/output.js';
+
+export function registerBuild(program) {
+  program
+    .command('build')
+    .description('Build default Docker image')
+    .option('-f, --force', 'Force rebuild (ignore existing image)')
+    .option('-q, --quiet', 'Minimal output during build')
+    .action(async (options) => {
+      const builder = new ImageBuilder();
+      try {
+        if (options.force) {
+          await builder.removeImage();
+        }
+        const origWrite = process.stdout.write;
+        if (options.quiet) {
+          process.stdout.write = () => true;
+        }
+        const ok = await builder.buildDefaultImage();
+        if (options.quiet) process.stdout.write = origWrite;
+        if (ok) console.log(success('Image build complete'));
+        else console.log(errorColor('Image build failed'));
+      } catch (err) {
+        console.error(errorColor(`Error: ${err.message}`));
+      }
+    });
+}

--- a/src/cli/commands/help.js
+++ b/src/cli/commands/help.js
@@ -1,0 +1,14 @@
+export function registerHelp(program) {
+  program
+    .command('help [command]')
+    .description('Show help for command')
+    .action((cmd) => {
+      if (cmd) {
+        const sub = program.commands.find((c) => c.name() === cmd);
+        if (sub) sub.help();
+        else console.log(`Unknown command: ${cmd}`);
+      } else {
+        program.help();
+      }
+    });
+}

--- a/src/cli/commands/logs.js
+++ b/src/cli/commands/logs.js
@@ -1,0 +1,8 @@
+export function registerLogs(program) {
+  program
+    .command('logs')
+    .description('Launch trace viewer (TUI)')
+    .action(async () => {
+      await import('../../tui/tui-launcher.js');
+    });
+}

--- a/src/cli/commands/project.js
+++ b/src/cli/commands/project.js
@@ -1,0 +1,87 @@
+import fs from 'fs-extra';
+import path from 'path';
+import ProjectManager from '../../core/project-manager.js';
+import ContainerManager from '../../core/container-manager.js';
+import { success, error as errorColor, warn } from '../utils/output.js';
+import { createDefaultConfig } from '../utils/project-utils.js';
+
+export function registerProjectCommands(program) {
+  program
+    .command('start <project>')
+    .description('Start project container')
+    .action(async (project) => {
+      const pm = new ProjectManager();
+      await pm.initialize();
+      const cm = new ContainerManager(pm);
+      try {
+        pm.validateProjectName(project);
+        const result = await cm.startContainer(project);
+        console.log(success(`Started: ${result.containerId}`));
+      } catch (err) {
+        console.error(errorColor(`Error: ${err.message}`));
+      }
+    });
+
+  program
+    .command('stop <project>')
+    .description('Stop project container')
+    .action(async (project) => {
+      const pm = new ProjectManager();
+      await pm.initialize();
+      const cm = new ContainerManager(pm);
+      try {
+        pm.validateProjectName(project);
+        await cm.stopContainer(project);
+        console.log(success('Stopped'));
+      } catch (err) {
+        console.error(errorColor(`Error: ${err.message}`));
+      }
+    });
+
+  program
+    .command('create <project>')
+    .description('Create new project')
+    .action(async (project) => {
+      const pm = new ProjectManager();
+      await pm.initialize();
+      try {
+        pm.validateProjectName(project);
+        const projectDir = path.join(pm.projectsDir, project);
+        if (await fs.pathExists(projectDir)) {
+          console.log(warn('Project already exists'));
+          return;
+        }
+        const config = await createDefaultConfig(project);
+        await fs.ensureDir(projectDir);
+        await fs.writeJSON(path.join(projectDir, 'config.json'), config, {
+          spaces: 2,
+        });
+        console.log(success(`Created project at ${projectDir}`));
+      } catch (err) {
+        console.error(errorColor(`Error: ${err.message}`));
+      }
+    });
+
+  program
+    .command('recreate <project>')
+    .description('Recreate project container')
+    .action(async (project) => {
+      const pm = new ProjectManager();
+      await pm.initialize();
+      const cm = new ContainerManager(pm);
+      try {
+        pm.validateProjectName(project);
+        await cm.stopContainer(project);
+        try {
+          const container = cm.docker.getContainer(`dockashell-${project}`);
+          await container.remove({ force: true });
+        } catch {
+          /* ignore */
+        }
+        await cm.startContainer(project);
+        console.log(success('Recreated container'));
+      } catch (err) {
+        console.error(errorColor(`Error: ${err.message}`));
+      }
+    });
+}

--- a/src/cli/commands/serve.js
+++ b/src/cli/commands/serve.js
@@ -1,0 +1,13 @@
+import DockashellServer from '../../mcp/mcp-server.js';
+
+export function registerServe(program) {
+  program
+    .command('serve')
+    .description('Start MCP server')
+    .option('--http', 'Start HTTP server (coming soon)')
+    .option('-v, --verbose', 'Enable debug logging')
+    .action(async () => {
+      const server = new DockashellServer();
+      await server.run();
+    });
+}

--- a/src/cli/commands/status.js
+++ b/src/cli/commands/status.js
@@ -1,0 +1,55 @@
+import { checkDockerDaemon, checkImageExists } from '../utils/docker-utils.js';
+import { getProjectsStatus } from '../utils/project-utils.js';
+import ProjectManager from '../../core/project-manager.js';
+import { success, error as errorColor, warn, bold } from '../utils/output.js';
+
+export function registerStatus(program) {
+  program
+    .command('status')
+    .description('Show system and project status')
+    .option('--json', 'Output JSON')
+    .action(async (options) => {
+      const projectManager = new ProjectManager();
+      await projectManager.initialize();
+
+      const docker = await checkDockerDaemon();
+      const image = await checkImageExists('dockashell/default-dev:latest');
+      const projects = await getProjectsStatus(projectManager);
+
+      if (options.json) {
+        console.log(JSON.stringify({ docker, image, projects }, null, 2));
+        return;
+      }
+
+      if (docker.running) {
+        console.log(`${success('✓')} Docker running (${docker.version})`);
+      } else {
+        console.log(
+          `${errorColor('✖ Docker not available')} - ${docker.error}`
+        );
+      }
+
+      if (image.exists) {
+        console.log(
+          `${success('✓')} Default image built (created ${image.created})`
+        );
+      } else {
+        console.log(warn('⚠ Default image missing'));
+      }
+
+      if (projects.length === 0) {
+        console.log(warn('No projects configured'));
+      } else {
+        console.log(bold('\nProjects'));
+        projects.forEach((p) => {
+          const stateColor =
+            p.state === 'running'
+              ? success(p.state)
+              : p.state === 'stopped'
+                ? warn(p.state)
+                : errorColor(p.state);
+          console.log(`- ${p.name} [${stateColor}]`);
+        });
+      }
+    });
+}

--- a/src/cli/utils/docker-utils.js
+++ b/src/cli/utils/docker-utils.js
@@ -1,0 +1,33 @@
+import Docker from 'dockerode';
+
+const docker = new Docker();
+
+export async function checkDockerDaemon() {
+  try {
+    const info = await docker.info();
+    return { running: true, version: info.ServerVersion };
+  } catch (err) {
+    return { running: false, error: err.message };
+  }
+}
+
+export async function checkImageExists(image) {
+  try {
+    const data = await docker.getImage(image).inspect();
+    return { exists: true, created: data.Created };
+  } catch {
+    return { exists: false };
+  }
+}
+
+export async function getContainerState(name) {
+  try {
+    const data = await docker.getContainer(name).inspect();
+    return { exists: true, running: data.State.Running };
+  } catch (err) {
+    if (err.statusCode === 404) {
+      return { exists: false, running: false };
+    }
+    throw err;
+  }
+}

--- a/src/cli/utils/output.js
+++ b/src/cli/utils/output.js
@@ -1,0 +1,23 @@
+import pc from 'picocolors';
+
+export function success(text) {
+  return pc.green(text);
+}
+
+export function error(text) {
+  return pc.red(text);
+}
+
+export function warn(text) {
+  return pc.yellow(text);
+}
+
+export function info(text) {
+  return pc.cyan(text);
+}
+
+export function bold(text) {
+  return pc.bold(text);
+}
+
+export const colors = pc;

--- a/src/cli/utils/project-utils.js
+++ b/src/cli/utils/project-utils.js
@@ -1,0 +1,39 @@
+import path from 'path';
+import os from 'os';
+import fs from 'fs-extra';
+import { getContainerState } from './docker-utils.js';
+
+export async function getProjectsStatus(projectManager) {
+  const projects = await projectManager.listProjects();
+  const results = [];
+  for (const project of projects) {
+    const state = await getContainerState(`dockashell-${project.name}`);
+    let status = 'missing';
+    if (state.exists) {
+      status = state.running ? 'running' : 'stopped';
+    }
+    results.push({ ...project, state: status });
+  }
+  return results;
+}
+
+export async function createDefaultConfig(projectName) {
+  const dir = path.join(os.homedir(), 'projects', projectName);
+  const config = {
+    name: projectName,
+    mounts: [
+      {
+        host: `~/projects/${projectName}`,
+        container: '/workspace',
+        readonly: false,
+      },
+    ],
+    ports: [],
+    environment: {},
+    working_dir: '/workspace',
+    shell: '/bin/bash',
+    security: { max_execution_time: 300 },
+  };
+  await fs.ensureDir(dir);
+  return config;
+}

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -1,0 +1,33 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'path';
+
+const cliPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../src/cli/cli.js'
+);
+
+function run(args) {
+  return new Promise((resolve) => {
+    execFile(
+      'node',
+      [cliPath, ...args],
+      { env: { ...process.env } },
+      (err, stdout) => {
+        resolve({ code: err && err.code ? err.code : 0, stdout });
+      }
+    );
+  });
+}
+
+test('shows version', async () => {
+  const result = await run(['--version']);
+  assert.strictEqual(result.stdout.trim(), '0.1.0');
+});
+
+test('shows help', async () => {
+  const result = await run(['help']);
+  assert.ok(result.stdout.includes('Usage'));
+});


### PR DESCRIPTION
## Summary
- implement CLI with multiple commands
- add supporting utils for Docker status and projects
- register commands in new cli.js
- wire `dockashell` bin to CLI
- include simple CLI tests

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_683dbb1a83048324888f2652043571db