### PR TITLE
Remove example setup script and add config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,6 @@ npm install
 npm run build-image
 ```
 
-### 3. Create Example Projects
-
-```bash
-npm run setup-examples
-```
-
 ## 🐳 Default Development Image
 
 DockaShell includes a comprehensive default development image (`dockashell/default-dev:latest`) with:

--- a/docs/default-image-implementation.md
+++ b/docs/default-image-implementation.md
@@ -14,7 +14,6 @@ This implementation adds a comprehensive default Docker image approach to DockaS
 ### Modified Files
 
 - `src/project-manager.js` - Updated to use default image (`dockashell/default-dev:latest`)
-- `scripts/setup/create-examples.js` - Simplified example projects using default image
 - `package.json` - Added new npm scripts
 - `README.md` - Updated documentation with default image information
 
@@ -45,7 +44,6 @@ This implementation adds a comprehensive default Docker image approach to DockaS
 ```bash
 npm run build-image        # Build default image
 npm run rebuild-image      # Force rebuild existing image
-npm run setup-examples     # Create example projects
 ```
 
 ## 🔄 Project Configuration Changes
@@ -97,7 +95,6 @@ git clone <repository>
 cd dockashell
 npm install
 npm run build-image
-npm run setup-examples
 ```
 
 ### Development Workflow
@@ -106,9 +103,6 @@ npm run setup-examples
 # Build or rebuild the default image
 npm run build-image
 npm run rebuild-image
-
-# Create example projects
-npm run setup-examples
 
 # Start the MCP server
 npm start

--- a/docs/project-configuration.md
+++ b/docs/project-configuration.md
@@ -1,0 +1,60 @@
+# Project Configuration
+
+DockaShell stores each project's config in `~/.dockashell/projects/{name}/config.json`. These JSON files define how containers are started.
+
+## Common Fields
+
+- `name` – Project name
+- `description` – Optional description
+- `image` – Docker image to use (defaults to `dockashell/default-dev:latest`)
+- `mounts` – List of host paths mounted into the container
+- `ports` – Ports forwarded from host to container
+- `environment` – Environment variables
+- `working_dir` – Default working directory inside the container
+- `shell` – Login shell
+- `security.max_execution_time` – Maximum seconds for any command
+
+## Example: Node.js Web App
+
+```json
+{
+  "name": "web-app",
+  "description": "Node.js web application with hot reload",
+  "mounts": [
+    {
+      "host": "~/projects/web-app",
+      "container": "/workspace",
+      "readonly": false
+    }
+  ],
+  "ports": [
+    { "host": 3000, "container": 3000 },
+    { "host": 8080, "container": 8080 }
+  ],
+  "environment": {
+    "NODE_ENV": "development"
+  },
+  "working_dir": "/workspace",
+  "shell": "/bin/bash",
+  "security": { "max_execution_time": 300 }
+}
+```
+
+## Example: Custom Image
+
+```json
+{
+  "name": "legacy-app",
+  "image": "node:16-bullseye",
+  "mounts": [
+    {
+      "host": "~/projects/legacy-app",
+      "container": "/workspace",
+      "readonly": false
+    }
+  ],
+  "ports": [{ "host": 3000, "container": 3000 }],
+  "working_dir": "/workspace",
+  "shell": "/bin/bash"
+}
+```

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "format": "prettier --write .",
     "format:md": "prettier --write '**/*.md'",
     "format:check": "prettier --check .",
-    "setup-examples": "node scripts/setup/create-examples.js",
     "build-image": "node scripts/image/build-default-image.js",
     "rebuild-image": "node scripts/image/build-default-image.js --rebuild",
     "dev": "node src/tui/tui-launcher.js"


### PR DESCRIPTION
## Summary
- drop `setup-examples` npm script
- clean up documentation references
- document project configuration examples

## Testing
- `npm run lint:fix`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683dcaacc0508324bb47c01f8cb42c0a