### PR TITLE
Add project arg to logs command

### DIFF
--- a/src/cli/commands/logs.js
+++ b/src/cli/commands/logs.js
@@ -1,8 +1,37 @@
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { error as errorColor } from '../utils/output.js';
+
 export function registerLogs(program) {
   program
-    .command('logs')
+    .command('logs [project]')
     .description('Launch trace viewer (TUI)')
-    .action(async () => {
-      await import('../../tui/tui-launcher.js');
+    .action(async (project) => {
+      if (process.env.DS_SKIP_TUI) return;
+
+      try {
+        const __filename = fileURLToPath(import.meta.url);
+        const tuiPath = path.join(
+          path.dirname(__filename),
+          '..',
+          '..',
+          'tui',
+          'tui-launcher.js'
+        );
+        const args = [tuiPath];
+        if (project) args.push(project);
+        const child = spawn('node', args, { stdio: 'inherit' });
+        child.on('error', (err) => {
+          console.error(errorColor(`Error: ${err.message}`));
+          process.exit(1);
+        });
+        child.on('exit', (code) => {
+          process.exit(code ?? 0);
+        });
+      } catch (err) {
+        console.error(errorColor(`Error: ${err.message}`));
+        process.exit(1);
+      }
     });
 }

--- a/test/cli/logs-command.test.js
+++ b/test/cli/logs-command.test.js
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'path';
+
+const cliPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../src/cli/cli.js'
+);
+
+function run(args) {
+  return new Promise((resolve) => {
+    execFile(
+      'node',
+      [cliPath, ...args],
+      { env: { ...process.env, DS_SKIP_TUI: '1' } },
+      (err, stdout, stderr) => {
+        resolve({ code: err && err.code ? err.code : 0, stdout, stderr });
+      }
+    );
+  });
+}
+
+test('logs accepts optional project argument', async () => {
+  const result = await run(['logs', 'myproj']);
+  assert.strictEqual(result.code, 0);
+  assert.ok(!result.stderr.includes('too many arguments'));
+});
+
+test('logs without argument opens selector', async () => {
+  const result = await run(['logs']);
+  assert.strictEqual(result.code, 0);
+});


### PR DESCRIPTION
## Summary
- allow optional project argument for `dockashell logs`
- spawn TUI with provided project name
- add CLI tests for new `logs` behaviour

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_683dd9d93f2883248e6b4629b781df96