### PR TITLE
Implement CLI polish

### DIFF
--- a/src/cli/commands/build.js
+++ b/src/cli/commands/build.js
@@ -1,31 +1,37 @@
 import { ImageBuilder } from '../utils/image-builder.js';
 import { success, error as errorColor } from '../utils/output.js';
 import { checkDockerDaemon } from '../utils/docker-utils.js';
+import { confirm } from '../utils/prompts.js';
 
 export function registerBuild(program) {
   program
     .command('build')
     .description('Build default Docker image')
     .option('-f, --force', 'Force rebuild (ignore existing image)')
-    .option('-q, --quiet', 'Minimal output during build')
     .action(async (options) => {
       const docker = await checkDockerDaemon();
       if (!docker.running) {
-        console.error(errorColor('Docker daemon not running'));
+        console.error(
+          errorColor(
+            "Docker daemon not running. Please start Docker Desktop or run 'sudo systemctl start docker'"
+          )
+        );
         process.exit(1);
       }
 
       const builder = new ImageBuilder();
       try {
         if (options.force) {
+          const confirmed = await confirm(
+            'This will remove the existing image and rebuild from scratch.'
+          );
+          if (!confirmed) {
+            console.log('Build cancelled');
+            return;
+          }
           await builder.removeImage();
         }
-        const origWrite = process.stdout.write;
-        if (options.quiet) {
-          process.stdout.write = () => true;
-        }
         const ok = await builder.buildDefaultImage();
-        if (options.quiet) process.stdout.write = origWrite;
         if (ok) console.log(success('Image build complete'));
         else console.log(errorColor('Image build failed'));
       } catch (err) {

--- a/src/cli/utils/docker-utils.js
+++ b/src/cli/utils/docker-utils.js
@@ -3,6 +3,9 @@ import Docker from 'dockerode';
 const docker = new Docker();
 
 export async function checkDockerDaemon() {
+  if (process.env.DS_TEST_DOCKER) {
+    return { running: true, version: 'test' };
+  }
   try {
     const info = await docker.info();
     return { running: true, version: info.ServerVersion };

--- a/src/cli/utils/prompts.js
+++ b/src/cli/utils/prompts.js
@@ -1,0 +1,26 @@
+import { createInterface } from 'readline';
+
+export async function confirm(message, defaultValue = false) {
+  if (process.env.DS_AUTO_CONFIRM) {
+    return defaultValue;
+  }
+
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  const suffix = defaultValue ? ' [Y/n]' : ' [y/N]';
+
+  return new Promise((resolve) => {
+    rl.question(message + suffix + ' ', (answer) => {
+      rl.close();
+      if (!answer) {
+        resolve(defaultValue);
+        return;
+      }
+      const normalized = answer.toLowerCase().trim();
+      resolve(normalized === 'y' || normalized === 'yes');
+    });
+  });
+}

--- a/src/cli/utils/validation.js
+++ b/src/cli/utils/validation.js
@@ -1,0 +1,19 @@
+import ProjectManager from '../../core/project-manager.js';
+
+export function validateProjectNameWithSuggestions(name) {
+  const pm = new ProjectManager();
+  try {
+    pm.validateProjectName(name);
+    return { valid: true };
+  } catch (error) {
+    const suggestions = [];
+    if (/[A-Z]/.test(name)) {
+      suggestions.push(`Try: ${name.toLowerCase()}`);
+    }
+    if (/[^a-z0-9_-]/.test(name)) {
+      const fixed = name.toLowerCase().replace(/[^a-z0-9_-]/g, '-');
+      suggestions.push(`Try: ${fixed}`);
+    }
+    return { valid: false, error: error.message, suggestions };
+  }
+}

--- a/src/core/project-manager.js
+++ b/src/core/project-manager.js
@@ -192,13 +192,22 @@ class ProjectManager {
     if (name.length === 0) {
       throw new Error('Project name cannot be empty');
     }
-    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+    if (!/^[a-z0-9][a-z0-9_-]*$/.test(name)) {
       throw new Error(
-        'Project name can only contain letters, numbers, hyphens, and underscores'
+        'Project name must start with letter/number and contain only lowercase letters, numbers, hyphens, and underscores'
       );
     }
     if (name.length > 64) {
       throw new Error('Project name must be 64 characters or less');
+    }
+
+    const reserved = ['docker', 'system', 'default', 'localhost'];
+    if (reserved.includes(name)) {
+      throw new Error(`'${name}' is a reserved name`);
+    }
+
+    if (name.startsWith('-') || name.endsWith('-')) {
+      throw new Error('Project name cannot start or end with hyphen');
     }
   }
 }

--- a/test/cli/build-command.test.js
+++ b/test/cli/build-command.test.js
@@ -1,0 +1,35 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'path';
+
+const cliPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../src/cli/cli.js'
+);
+
+function run(args, env = {}) {
+  return new Promise((resolve) => {
+    execFile(
+      'node',
+      [cliPath, ...args],
+      { env: { ...process.env, DS_TEST_DOCKER: '1', ...env } },
+      (err, stdout, stderr) => {
+        resolve({ code: err && err.code ? err.code : 0, stdout, stderr });
+      }
+    );
+  });
+}
+
+test('build command rejects quiet flag', async () => {
+  const result = await run(['build', '--quiet']);
+  assert.notStrictEqual(result.code, 0);
+  assert.ok(result.stderr.includes('unknown option'));
+});
+
+test('build command shows cancellation for force rebuild', async () => {
+  const result = await run(['build', '--force'], { DS_AUTO_CONFIRM: '1' });
+  assert.strictEqual(result.code, 0);
+  assert.ok(result.stdout.includes('Build cancelled'));
+});

--- a/test/cli/project-commands.test.js
+++ b/test/cli/project-commands.test.js
@@ -1,0 +1,41 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'path';
+
+const cliPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../src/cli/cli.js'
+);
+
+function run(args, env = {}) {
+  return new Promise((resolve) => {
+    execFile(
+      'node',
+      [cliPath, ...args],
+      { env: { ...process.env, DS_TEST_DOCKER: '1', ...env } },
+      (err, stdout, stderr) => {
+        resolve({ code: err && err.code ? err.code : 0, stdout, stderr });
+      }
+    );
+  });
+}
+
+test('start command validates project name', async () => {
+  const result = await run(['start', 'Invalid-Name!']);
+  assert.strictEqual(result.code, 1);
+  assert.ok(result.stderr.includes('lowercase letters'));
+});
+
+test('create command rejects reserved names', async () => {
+  const result = await run(['create', 'docker']);
+  assert.strictEqual(result.code, 1);
+  assert.ok(result.stderr.includes('reserved name'));
+});
+
+test('recreate command requires confirmation', async () => {
+  const result = await run(['recreate', 'proj'], { DS_AUTO_CONFIRM: '1' });
+  assert.strictEqual(result.code, 0);
+  assert.ok(result.stdout.includes('Operation cancelled'));
+});

--- a/test/cli/prompts.test.js
+++ b/test/cli/prompts.test.js
@@ -1,0 +1,10 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { confirm } from '../../src/cli/utils/prompts.js';
+
+test('confirm respects DS_AUTO_CONFIRM environment variable', async () => {
+  process.env.DS_AUTO_CONFIRM = '1';
+  const result = await confirm('Test?', true);
+  assert.strictEqual(result, true);
+  delete process.env.DS_AUTO_CONFIRM;
+});

--- a/test/cli/validation.test.js
+++ b/test/cli/validation.test.js
@@ -1,0 +1,9 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { validateProjectNameWithSuggestions } from '../../src/cli/utils/validation.js';
+
+test('project name validation provides helpful suggestions', () => {
+  const result = validateProjectNameWithSuggestions('My-Project!');
+  assert.strictEqual(result.valid, false);
+  assert.ok(result.suggestions.some((s) => s.includes('my-project')));
+});

--- a/test/core/project-manager.test.js
+++ b/test/core/project-manager.test.js
@@ -96,12 +96,12 @@ describe('ProjectManager', () => {
 
     await assert.rejects(
       async () => await projectManager.loadProject('../../malicious'),
-      /can only contain letters/
+      /lowercase letters/
     );
 
     await assert.rejects(
       async () => await projectManager.loadProject('project with spaces'),
-      /can only contain letters/
+      /lowercase letters/
     );
   });
 


### PR DESCRIPTION
## Summary
- remove quiet flag and add confirmation in build command
- improve project validation rules
- add confirmation prompts utility
- enhance error messaging for docker checks and port hints
- add helper validation and new CLI tests
- add DS_TEST_DOCKER flag for test environments
- use validation suggestions in project commands and restrict port hints

## Testing
- `npm run format`
- `npm run lint:fix`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683ddeaac57c8324b826ed7af00ef5b8