### PR TITLE
Improve CLI help & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,28 @@ DockaShell is an experimental project under active development. It is not yet st
 ### 1. Installation
 
 ```bash
+npm install -g dockashell
+# OR for development:
 git clone <repository>
 cd dockashell
 npm install
+npm link  # Makes dockashell command available
 ```
 
-### 2. Build the Default Docker Image
+### 2. Initial Setup
 
 ```bash
+# Check system status
+dockashell status
+
+# Build default development image
 dockashell build
+
+# Create your first project
+dockashell create my-project
+
+# Start working
+dockashell start my-project
 ```
 
 ## 🐳 Default Development Image
@@ -86,43 +99,9 @@ dockashell build
 dockashell build --force
 ```
 
-## 📝 Example Workflow
+## 📝 CLI Usage
 
-Here's how an AI agent would typically use DockaShell:
-
-```javascript
-// 1. List available projects
-list_projects();
-
-// 2. Start a web development project
-start_project({ project_name: 'web-app' });
-
-// 3. Initialize a new Node.js project
-bash({
-  project_name: 'web-app',
-  command: 'npm init -y',
-});
-
-// 4. Install dependencies
-bash({
-  project_name: 'web-app',
-  command: 'npm install express',
-});
-
-// 5. Create a simple server
-bash({
-  project_name: 'web-app',
-  command: 'echo \'const express = require("express"); const app = express(); app.get("/", (req, res) => res.send("Hello World!")); app.listen(3000);\' > app.js',
-});
-
-// 6. Start the server
-bash({
-  project_name: 'web-app',
-  command: 'node app.js',
-});
-
-// Server is now running at http://localhost:3000
-```
+See [docs/cli-usage.md](docs/cli-usage.md) for workflow examples and full command reference.
 
 ## ⚙️ Configuration
 
@@ -265,7 +244,15 @@ Trace sessions rotate automatically when there are more than four hours between 
 }
 ```
 
-## 🔌 MCP Client Integration
+## 🔌 Installation & Integration
+
+### CLI Installation
+
+```bash
+npm install -g dockashell
+```
+
+### AI Client Integration
 
 Add to your MCP client configuration:
 
@@ -273,23 +260,21 @@ Add to your MCP client configuration:
 {
   "mcpServers": {
     "dockashell": {
-      "command": "node",
-      "args": ["path/to/dockashell/src/mcp/mcp-server.js"]
+      "command": "dockashell",
+      "args": ["serve"]
     }
   }
 }
 ```
 
-Or if installed globally:
+### Development Setup
 
-```json
-{
-  "mcpServers": {
-    "dockashell": {
-      "command": "dockashell"
-    }
-  }
-}
+```bash
+git clone <repository>
+cd dockashell
+npm install
+npm link              # Make CLI available globally
+dockashell build      # Build default image
 ```
 
 ## 📋 Requirements

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -1,0 +1,87 @@
+# DockaShell CLI Usage
+
+This guide covers common workflows and the full command reference for the `dockashell` CLI.
+
+## 📝 CLI Workflow Examples
+
+### Web Development Project
+
+```bash
+# Create and start project
+dockashell create web-app
+dockashell start web-app
+
+# Monitor activity
+dockashell logs web-app
+
+# Make config changes, then apply
+# (edit ~/.dockashell/projects/web-app/config.json)
+dockashell recreate web-app
+```
+
+### Data Science Project
+
+```bash
+# Create project with default Python/Jupyter setup
+dockashell create data-analysis
+dockashell start data-analysis
+
+# View real-time traces
+dockashell logs
+```
+
+### Multi-Project Management
+
+```bash
+# Overview of all projects
+dockashell status
+
+# Start multiple projects
+dockashell start web-app
+dockashell start api-service
+dockashell start frontend
+
+# Stop when done
+dockashell stop web-app
+dockashell stop api-service
+```
+
+## 📖 CLI Reference
+
+### Status & Health
+
+```bash
+dockashell status           # System overview
+dockashell status --json    # Machine-readable output
+```
+
+### Image Management
+
+```bash
+dockashell build            # Build default image
+dockashell build --force    # Force rebuild
+```
+
+### Project Lifecycle
+
+```bash
+dockashell create <name>    # Create new project
+dockashell start <name>     # Start project container
+dockashell stop <name>      # Stop project container
+dockashell recreate <name>  # Apply config changes
+```
+
+### Monitoring & Debugging
+
+```bash
+dockashell logs             # Interactive trace viewer
+dockashell logs <project>   # View specific project
+```
+
+### AI Integration
+
+```bash
+dockashell serve            # Start MCP server
+```
+
+For detailed help: `dockashell help <command>`

--- a/src/cli/commands/help.js
+++ b/src/cli/commands/help.js
@@ -1,14 +1,231 @@
+// Enhanced help content for DockaShell CLI
+
+const MAIN_HELP = `
+DockaShell v0.1.0
+AI agent secure Docker environments for project work
+
+USAGE:
+  dockashell <command> [options]
+
+COMMANDS:
+  status [--json]           Show Docker status, images, and all projects
+  build [--force]           Build default development image  
+  start <project>           Start project container
+  stop <project>            Stop project container
+  create <project>          Create new project configuration
+  recreate <project>        Rebuild container (apply config changes)
+  logs [project]            Launch interactive trace viewer
+  serve [--http]            Start MCP server for AI integration
+  help [command]            Show detailed help for command
+
+EXAMPLES:
+  dockashell status                   # Check system health
+  dockashell build --force            # Rebuild default image
+  dockashell create web-app           # Create new project
+  dockashell start web-app            # Start working on project
+  dockashell logs                     # Monitor all activity
+  dockashell recreate web-app         # Apply config changes
+
+Run 'dockashell help <command>' for detailed information.
+For more: https://github.com/your-org/dockashell
+`;
+
+const DETAILED_HELP = {
+  status: `
+COMMAND: status
+Show comprehensive system status including Docker daemon, 
+default image, and all projects with container states.
+
+USAGE:
+  dockashell status [--json]
+
+OPTIONS:
+  --json                   Output machine-readable JSON
+
+OUTPUT INCLUDES:
+  • Docker daemon status and version  
+  • Default image availability and build date
+  • All projects with container states (running/stopped/missing)
+  • Port usage and basic resource summary
+
+EXAMPLES:
+  dockashell status                   # Human-readable overview
+  dockashell status --json            # For scripts/automation
+`,
+
+  build: `
+COMMAND: build  
+Build the default DockaShell development image with Python 3.12,
+Node.js 20 LTS, and essential development tools.
+
+USAGE:
+  dockashell build [--force]
+
+OPTIONS:
+  -f, --force              Force rebuild (remove existing image first)
+
+BUILD DETAILS:
+  • Image: dockashell/default-dev:latest
+  • Base: Microsoft Python 3.12 devcontainer  
+  • Build time: 2-5 minutes on first run
+  • Includes: Python, Node.js, npm, yarn, ripgrep, jq
+
+EXAMPLES:
+  dockashell build                    # Build if missing
+  dockashell build --force            # Force fresh rebuild
+`,
+
+  start: `
+COMMAND: start
+Start a project container. Creates container from config if needed.
+
+USAGE:  
+  dockashell start <project>
+
+REQUIREMENTS:
+  • Project config must exist: ~/.dockashell/projects/<project>/config.json
+  • Docker daemon must be running
+  • Default image must be built
+
+BEHAVIOR:
+  • Creates container with configured mounts, ports, environment
+  • Uses existing container if already created
+  • Mounts project directory to /workspace by default
+
+EXAMPLES:
+  dockashell start web-app            # Start web-app project
+  dockashell start data-analysis      # Start data project
+`,
+
+  stop: `
+COMMAND: stop
+Stop a running project container gracefully.
+
+USAGE:
+  dockashell stop <project>
+
+BEHAVIOR:
+  • Sends SIGTERM with 10 second grace period
+  • Preserves container state for future start
+  • Safe to run on already stopped containers
+
+EXAMPLES:
+  dockashell stop web-app             # Stop specific project
+`,
+
+  create: `
+COMMAND: create  
+Create a new project with default configuration.
+
+USAGE:
+  dockashell create <project>
+
+BEHAVIOR:
+  • Creates ~/.dockashell/projects/<project>/ directory
+  • Generates default config.json with common settings
+  • Sets up workspace mount to ~/projects/<project>
+  • Configures common development ports (3000, 8000, etc.)
+
+PROJECT NAMING:
+  • Use lowercase letters, numbers, hyphens, underscores only
+  • No spaces or special characters
+
+EXAMPLES:
+  dockashell create my-web-app        # Create web project
+  dockashell create data-science      # Create data project  
+`,
+
+  recreate: `
+COMMAND: recreate
+Stop, remove, and restart project container to apply configuration changes.
+
+USAGE:
+  dockashell recreate <project>
+
+USE CASES:
+  • Applied changes to config.json (ports, mounts, environment)
+  • Updated default image and want to use new version
+  • Container corrupted or needs fresh start
+
+BEHAVIOR:  
+  • Stops running container
+  • Removes container (preserves project files)
+  • Creates new container with current config
+  • Starts new container
+
+EXAMPLES:
+  dockashell recreate web-app         # Apply config changes
+`,
+
+  logs: `
+COMMAND: logs
+Launch interactive trace viewer (TUI) for monitoring project activity.
+
+USAGE:
+  dockashell logs [project]
+
+FEATURES:
+  • View all project activity in real-time
+  • Filter by trace type (commands, notes, errors)
+  • Search across all traces
+  • Navigate with keyboard shortcuts
+  • Project selector if no project specified
+
+KEYBOARD SHORTCUTS:
+  • ↑↓ Navigate traces
+  • Enter: View trace details  
+  • f: Filter by type
+  • /: Search
+  • q: Quit
+
+EXAMPLES:
+  dockashell logs                     # Show project selector
+  dockashell logs web-app             # Open specific project
+`,
+
+  serve: `
+COMMAND: serve
+Start MCP (Model Context Protocol) server for AI agent integration.
+
+USAGE:
+  dockashell serve [--http]
+
+TRANSPORT OPTIONS:
+  Default: stdio (for direct AI client integration)
+  --http: HTTP server (coming soon)
+
+INTEGRATION:
+  Add to AI client config:
+  {
+    "mcpServers": {
+      "dockashell": {
+        "command": "dockashell", 
+        "args": ["serve"]
+      }
+    }
+  }
+
+EXAMPLES:
+  dockashell serve                    # Start stdio server
+`,
+};
+
 export function registerHelp(program) {
+  program.helpInformation = () => MAIN_HELP;
+
   program
     .command('help [command]')
-    .description('Show help for command')
+    .description('Show detailed help for command')
     .action((cmd) => {
-      if (cmd) {
-        const sub = program.commands.find((c) => c.name() === cmd);
-        if (sub) sub.help();
-        else console.log(`Unknown command: ${cmd}`);
+      if (cmd && DETAILED_HELP[cmd]) {
+        console.log(DETAILED_HELP[cmd]);
+      } else if (cmd) {
+        console.log(`Unknown command: ${cmd}\n`);
+        console.log(
+          'Available commands: status, build, start, stop, create, recreate, logs, serve'
+        );
       } else {
-        program.help();
+        console.log(MAIN_HELP);
       }
     });
 }

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -31,7 +31,7 @@ test('shows version', async () => {
 
 test('shows help', async () => {
   const result = await run(['help']);
-  assert.ok(result.stdout.includes('Usage'));
+  assert.ok(result.stdout.includes('DockaShell v0.1.0'));
 });
 
 test('auto-creates config structure on first use', async () => {


### PR DESCRIPTION
## Summary
- overhaul help command with detailed docs for each command
- revise README quick start and installation info
- move CLI workflow and examples to new docs/cli-usage.md
- update tests for new help output

## Testing
- `npm test`
- `npm run lint:fix`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_683df108dd9483249cc4ff892c020c65